### PR TITLE
Fix dark mode toggle

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600;700&family=DM+Sans:wght@300;400;500;700&display=swap');
 @import "tailwindcss";
 
-@custom-variant dark (&:where(.dark, .dark *));
+@variant dark (&:where(.dark, .dark *));
 
 @theme {
   --color-cream: #F5F0EB;


### PR DESCRIPTION
## Summary
- Fix dark mode not applying when clicking the toggle button
- Changed `@custom-variant dark` to `@variant dark` in globals.css
- Tailwind v4 requires `@variant` to override built-in variants

## Test plan
- [ ] Click the sun/moon/monitor icon — dark mode should toggle immediately
- [ ] Refresh the page in dark mode — should stay dark (no flash)
- [ ] Set to "system" — should follow OS preference

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line CSS directive change that only affects how the `dark` variant is registered/applied, with no data or security impact.
> 
> **Overview**
> Fixes dark mode styling not applying by changing the Tailwind directive in `globals.css` from `@custom-variant dark` to `@variant dark`, ensuring the `.dark`-scoped variant is properly recognized (Tailwind v4 behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4139dccc04182772be63daff551fe889fa7fd2e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->