### PR TITLE
Reorganize theme docs and update build checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,35 +120,23 @@ stillpoint/
 
 ## Design System
 
-### Aesthetic: Warm Minimalism
-Kinfolk magazine meets high-end therapy office. NOT purple gradients, lotus flowers, or stock mountain photos.
+Users choose between themes via a pill selector. Theme CSS variables are defined in `src/styles/globals.css`. Each theme's full spec lives in its own file:
 
-### Colors
-```css
---cream:     #F5F0EB;
---charcoal:  #2C2C2C;
---sage:      #8B9D83;
---clay:      #C4A882;
---mist:      #D4D0CB;
---deep:      #1A1A1A;
-```
+- **[Minimalist](docs/themes/minimalist.md)** — Warm minimalism, cream/sage/charcoal. Default.
+- **[Aura](docs/themes/aura.md)** — Iridescent gradients, frosted glass, lavender/pink/mint.
 
-### Typography
-- **Display/Titles:** Cormorant Garamond (Google Fonts)
-- **Body/UI:** DM Sans (Google Fonts)
-
-### Principles
+### Shared Principles
 - Generous whitespace — the app should feel like exhaling
 - Subtle fade-in animations, no aggressive motion
 - No clutter, badges, gamification, or streaks
-- Dark mode for evening meditations (auto-detect + toggle)
 - Mobile-first
+- Typography: Cormorant Garamond (display) + DM Sans (body) via `next/font`
 
 ### Key UI States
 1. **Setup:** API key entry + upload zone. Clean, non-intimidating.
-2. **Processing:** Breathing circle. "Reading your story..." → "Understanding what you need..." → "Writing your meditations..."
+2. **Processing:** Breathing circle with progressive messages.
 3. **Gallery:** 5-6 cards with poetic titles. Voice selector at top.
-4. **Player:** Full-screen. Large serif text with word highlighting during audio. Breathing guide. Timer. Bell.
+4. **Player:** Full-screen. Large serif text. Breathing guide. Timer. Bell.
 
 ---
 
@@ -206,7 +194,7 @@ ELEVENLABS_API_KEY=              # Optional — text-only mode works without thi
 - No `any` type
 - No raw conversation data stored after parsing
 - No conversation content sent beyond /api/extract-themes
-- No purple gradients, lotus flowers, stock meditation imagery
+- No lotus flowers or stock meditation imagery
 - No Inter, Roboto, or Arial
 - No analytics, tracking, or telemetry
 - No user accounts or auth in v1
@@ -237,15 +225,15 @@ ELEVENLABS_API_KEY=              # Optional — text-only mode works without thi
 ### Phase 4: Audio
 - [x] VoiceSelector (6 voices + custom)
 - [x] /api/generate-audio route
-- [x] AudioPlayer component
+- [x] AudioPlayer component (ElevenLabs + Web Speech API fallback)
 - [x] SSML conversion
-- [ ] Text-audio sync (deferred to Phase 5 — needs MeditationPlayer)
+- [ ] Text-audio sync (word highlighting during playback)
 
 ### Phase 5: Player Polish
-- [ ] Full-screen MeditationPlayer
-- [ ] BreathGuide (4-7-8)
-- [ ] Timer + bell
-- [ ] Dark mode
+- [x] Full-screen MeditationPlayer
+- [x] BreathGuide (4-4-4-4 box breathing)
+- [x] Timer + bell
+- [x] Theme system (Minimalist + Aura, replaces dark mode)
 - [ ] Mobile optimization
 
 ### Phase 6: Ship

--- a/docs/themes/aura.md
+++ b/docs/themes/aura.md
@@ -1,0 +1,39 @@
+# Theme: Aura
+
+Iridescent gradients, frosted glass, soft ethereal glow. Inspired by abstract aura gradient art.
+
+## Colors
+
+```css
+--color-cream:     #F8F4FF;    /* Background — soft lavender white */
+--color-charcoal:  #2D2640;    /* Primary text — deep purple-grey */
+--color-sage:      #9B8EC4;    /* Accent — soft purple */
+--color-clay:      #D4A0C0;    /* Secondary accent — dusty rose */
+--color-mist:      #E8E0F0;    /* Borders — lavender mist */
+--color-deep:      #1C1528;    /* Hover states — deep violet */
+```
+
+## Background
+
+Three floating gradient blobs with `filter: blur(80px)` and slow drift animation:
+- **Blob 1:** Lavender/violet (`#C4B5FD → #A78BFA → #DDD6FE`), top-right
+- **Blob 2:** Pink/peach (`#FBCFE8 → #F9A8D4 → #FDE68A`), bottom-left
+- **Blob 3:** Mint/teal (`#A7F3D0 → #6EE7B7 → #A5F3FC`), center
+
+Animation: 20s ease-in-out infinite, gentle translate + scale shifts.
+
+## Component Styling
+
+- **Cards:** Frosted glass — `rgba(255,255,255,0.4)` + `backdrop-filter: blur(20px)`, white/purple border. Class: `aura-glass`
+- **Inputs:** Frosted — `rgba(255,255,255,0.5)` + blur, purple focus glow. Class: `aura-input`
+- **Buttons:** Purple gradient `#7C3AED → #A78BFA`. Class: `aura-btn`
+- **Breathing circle:** Rainbow gradient (`#C4B5FD → #F9A8D4 → #A5F3FC`) with glowing box-shadow animation
+- **Badges:** `rgba(167,139,250,0.15)` with `#7C3AED` text
+
+## CSS Class
+
+Applied via `theme-aura` on `<html>`. Overrides `--color-*` variables and scopes component classes with `.theme-aura .aura-*` selectors in `globals.css`.
+
+## Inspiration
+
+Abstract aura gradient art — soft blurred forms, holographic color shifts, ethereal and calming.

--- a/docs/themes/minimalist.md
+++ b/docs/themes/minimalist.md
@@ -1,0 +1,38 @@
+# Theme: Minimalist
+
+Default theme. Warm minimalism — Kinfolk magazine meets high-end therapy office.
+
+## Colors
+
+```css
+--color-cream:     #F5F0EB;    /* Background */
+--color-charcoal:  #2C2C2C;    /* Primary text */
+--color-sage:      #8B9D83;    /* Accent, interactive */
+--color-clay:      #C4A882;    /* Secondary accent */
+--color-mist:      #D4D0CB;    /* Borders, subtle UI */
+--color-deep:      #1A1A1A;    /* Hover states */
+```
+
+## Typography
+
+- **Display/Titles:** Cormorant Garamond (Google Fonts, loaded via next/font)
+- **Body/UI:** DM Sans (Google Fonts, loaded via next/font)
+
+## Aesthetic Principles
+
+- Generous whitespace — the app should feel like exhaling
+- Subtle fade-in animations, no aggressive motion
+- No clutter, badges, gamification, or streaks
+- Mobile-first
+
+## Component Styling
+
+- **Cards:** `bg-white/40 border border-mist`, subtle hover lift
+- **Inputs:** `bg-white/50 border border-mist`, sage focus ring
+- **Buttons:** `bg-charcoal text-cream`, darkens on hover
+- **Breathing circle:** Solid sage with scale/opacity animation
+- **Badges:** `bg-sage/10 text-sage`
+
+## CSS Class
+
+Applied via `theme-minimalist` on `<html>`. This is the default — no variable overrides needed, uses the `@theme` values directly.


### PR DESCRIPTION
## Summary
- Move design system spec from CLAUDE.md into `docs/themes/minimalist.md` and `docs/themes/aura.md`
- Each theme has its own file with colors, component styling, and aesthetic notes
- Update build phases checklist — Phase 5 mostly complete, remaining: mobile optimization + text-audio sync
- Remove outdated "no purple gradients" rule (Aura theme uses them intentionally)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)