### PR TITLE
Slim CLAUDE.md: 242 → 118 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,50 +2,36 @@
 
 Open source tool that transforms AI conversation history into personalized guided meditations with audio playback. Users export their Claude data, upload it, and receive meditations tailored to the emotional and psychological capacities they actually need right now.
 
+## Getting Started
+
+```
+npm install
+npm run dev     # http://localhost:3000
+npm run build   # verify before committing
+```
+
 ## Core Concept
 
-Stillpoint does NOT recite your problems back to you. It identifies what capacities you need — then builds meditations that develop those capacities using universal language.
+Stillpoint does NOT recite your problems back to you. It identifies what capacities you need — then builds meditations that develop those capacities using universal language. Two-layer model:
 
-### The Two-Layer Model
+1. **Capacity Extraction** — Read conversations, identify what the person needs to *practice*. Prompt in `.claude/skills/theme-extractor/SKILL.md`.
+2. **Meditation Generation** — Build those capacities using universal language. NEVER mention specific life details. 6 meditation types defined in `src/lib/meditationTypes.ts`. Prompt in `.claude/skills/meditation-writer/SKILL.md`.
 
-**Layer 1 — Capacity Extraction:** Read conversations, identify what the person needs to *practice*. Think like a therapist: "What muscle does this person need to build?"
+## Data Flow
 
-| What conversations reveal | Capacity needed | Meditation approach |
-|---|---|---|
-| Managing aging parent from distance | Presence despite distance, releasing control | Being fully here while trusting what you can't see |
-| Hostile team after involuntary reorg | Holding ground without absorbing hostility | Boundary visualization, centering in own authority |
-| Post-surgical recovery while life demands continue | Patience with healing | Body appreciation, radical acceptance of current limits |
-| Financial anxiety about family planning | Separating fear from planning | Distinguishing real from imagined, grounding in what you have |
-| Job search while employed, identity uncertainty | Trusting own trajectory | Reconnecting with evidence of capability, releasing attachment to titles |
-| Circular thinking, going in loops | Breaking rumination | Thought-watching, choosing one thing to release |
+```
+Upload JSON → parseExport.ts (client, strips to human msgs only)
+  → /api/extract-themes (server, Claude API)
+  → assignMeditationTypes (client, keyword scoring)
+  → /api/generate-meditation (server, Claude API, sequential)
+  → Gallery → Player
+```
 
-**Layer 2 — Meditation Generation:** Build those capacities using universal language. NEVER mention specific life details. The personalization is in *selecting the right capacity at the right time* — the script itself could be in a printed book.
-
-### The 6 Meditation Types
-
-1. **The Anchor** — Stability amidst chaos. Sensory grounding → breath stabilization → finding the still point.
-2. **The Release** — Surrendering control. Noticing what you're gripping → cost of holding → practicing release → discovering what remains.
-3. **The Bridge** — Tolerating transition. Honoring what was → sitting with not-knowing → sensing what's forming.
-4. **The Body** — Patience with healing. Gentle body awareness → gratitude for function → honoring limits → trusting the timeline.
-5. **The Thread** — Connection across distance. Feeling connection as energy → sending intention → trusting the thread.
-6. **The Ground** — Self-trust. Settling into your body → remembering a time you surprised yourself → carrying it as fact.
-
-Detailed prompts for extraction and generation live in their respective skills: `.claude/skills/theme-extractor/SKILL.md` and `.claude/skills/meditation-writer/SKILL.md`.
-
----
+Audio generates lazily per-meditation via `/api/generate-audio` (ElevenLabs) or Web Speech API fallback.
 
 ## Stack
 
-- **Framework:** Next.js 14+ (App Router, TypeScript)
-- **Styling:** Tailwind CSS
-- **AI:** Anthropic Claude API (`claude-sonnet-4-20250514`)
-- **Audio:** ElevenLabs TTS API (BYOK)
-- **Data Processing:** Client-side JSON parsing
-- **Storage:** localStorage only. No database.
-- **Deployment:** Vercel
-- **License:** MIT
-
----
+Next.js 16 (App Router) · TypeScript strict · Tailwind CSS 4 · Claude API (Sonnet) · ElevenLabs TTS (BYOK, optional) · localStorage only · Vercel deploy · MIT license
 
 ## Privacy Architecture (Non-Negotiable)
 
@@ -55,120 +41,18 @@ Detailed prompts for extraction and generation live in their respective skills: 
 - No user data stored on any server
 - No accounts, tracking, or analytics
 - One-click clear all cached data
-- Users self-host with their own API keys
-
----
-
-## File Structure
-
-```
-stillpoint/
-├── CLAUDE.md
-├── LEARNING.md
-├── .claude/
-│   ├── settings.json
-│   ├── skills/
-│   │   ├── meditation-writer/SKILL.md
-│   │   ├── theme-extractor/SKILL.md
-│   │   ├── privacy-checker/SKILL.md
-│   │   └── ux-reviewer/SKILL.md
-│   ├── agents/
-│   │   ├── meditation-agent.md
-│   │   └── test-agent.md
-│   └── .mcp.json
-├── src/
-│   ├── app/
-│   │   ├── page.tsx
-│   │   ├── processing/page.tsx
-│   │   ├── meditations/page.tsx
-│   │   └── play/[id]/page.tsx
-│   ├── app/api/
-│   │   ├── extract-themes/route.ts
-│   │   ├── generate-meditation/route.ts
-│   │   └── generate-audio/route.ts
-│   ├── components/
-│   │   ├── UploadZone.tsx
-│   │   ├── ApiKeySetup.tsx
-│   │   ├── ProcessingView.tsx
-│   │   ├── MeditationCard.tsx
-│   │   ├── MeditationPlayer.tsx
-│   │   ├── VoiceSelector.tsx
-│   │   ├── AudioPlayer.tsx
-│   │   ├── BreathGuide.tsx
-│   │   └── Timer.tsx
-│   ├── lib/
-│   │   ├── parseExport.ts
-│   │   ├── extractCapacities.ts
-│   │   ├── generateMeditation.ts
-│   │   ├── generateAudio.ts
-│   │   ├── meditationTypes.ts
-│   │   ├── voices.ts
-│   │   └── types.ts
-│   └── styles/globals.css
-├── public/sounds/bell.mp3
-├── .env.example
-├── .env.local
-├── package.json
-├── tailwind.config.ts
-├── tsconfig.json
-├── next.config.js
-├── LICENSE
-└── README.md
-```
-
----
+- API routes check `process.env` first (personal deploy), then BYOK keys from request
 
 ## Design System
 
-Users choose between themes via a pill selector. Theme CSS variables are defined in `src/styles/globals.css`. Each theme's full spec lives in its own file:
+Users choose between themes via a pill selector (`ThemeSelector.tsx`). Themes work by overriding Tailwind's `--color-*` CSS variables on `<html>` via `.theme-{name}` classes. All defined in `src/styles/globals.css`.
 
 - **[Minimalist](docs/themes/minimalist.md)** — Warm minimalism, cream/sage/charcoal. Default.
-- **[Aura](docs/themes/aura.md)** — Iridescent gradients, frosted glass, lavender/pink/mint.
+- **[Aura](docs/themes/aura.md)** — Iridescent gradient blobs, frosted glass, lavender/pink/mint.
 
-### Shared Principles
-- Generous whitespace — the app should feel like exhaling
-- Subtle fade-in animations, no aggressive motion
-- No clutter, badges, gamification, or streaks
-- Mobile-first
-- Typography: Cormorant Garamond (display) + DM Sans (body) via `next/font`
+To add a new theme: add entry to `THEMES` array in `ThemeSelector.tsx`, add `--color-*` overrides under `.theme-{name}` in `globals.css`, create `docs/themes/{name}.md`.
 
-### Key UI States
-1. **Setup:** API key entry + upload zone. Clean, non-intimidating.
-2. **Processing:** Breathing circle with progressive messages.
-3. **Gallery:** 5-6 cards with poetic titles. Voice selector at top.
-4. **Player:** Full-screen. Large serif text. Breathing guide. Timer. Bell.
-
----
-
-## ElevenLabs Audio
-
-- BYOK — user provides ElevenLabs API key (optional; text-only works without it)
-- 6 curated voices + custom Voice ID option
-- `[pause Xs]` → `<break time="Xs"/>` SSML conversion
-- `[breathe]` → `<break time="4s"/>`
-- `[bell]` → local bell.mp3 playback
-- Audio cached in localStorage as base64
-- Progressive loading: text appears first, audio generates in background
-- Player: play/pause, scrubber, 0.75x/1x/1.25x speed, text highlight sync
-
-Voice config lives in `src/lib/voices.ts`. Verify ElevenLabs voice IDs before shipping.
-
----
-
-## BYOK Setup
-
-### .env.example
-```
-ANTHROPIC_API_KEY=sk-ant-...
-ELEVENLABS_API_KEY=              # Optional — text-only mode works without this
-```
-
-### In-App Flow
-1. Anthropic key: required, link to console.anthropic.com
-2. ElevenLabs key: optional, "Skip — I'll read them myself"
-3. Keys in localStorage, sent only to respective APIs via server routes
-
----
+Typography: Cormorant Garamond (display) + DM Sans (body) via `next/font`.
 
 ## Git Workflow
 
@@ -176,8 +60,6 @@ ELEVENLABS_API_KEY=              # Optional — text-only mode works without thi
 - Never force push
 - Always run `npm run build` before committing to catch type errors
 - Use descriptive branch names (e.g., `phase-5-player-polish`, `fix-audio-fallback`)
-
----
 
 ## Coding Conventions
 
@@ -201,8 +83,6 @@ ELEVENLABS_API_KEY=              # Optional — text-only mode works without thi
 - No word "journey" in meditations
 - No specific life details in meditation scripts
 - No .env.local committed to repo
-
----
 
 ## Build Phases
 


### PR DESCRIPTION
## Summary
- Remove info that's duplicated in code or skill files (capacity table, meditation types, file tree, ElevenLabs details, BYOK setup)
- Add Getting Started, Data Flow, and theme mechanism docs
- Every remaining line is something Claude can't derive from reading the codebase

🤖 Generated with [Claude Code](https://claude.ai/claude-code)