### PR TITLE
Automate chat import: ZIP support, folder upload, freshness tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "jszip": "^3.10.1",
         "next": "^16.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -2661,6 +2662,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3965,6 +3972,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3991,6 +4004,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4534,6 +4553,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4576,6 +4607,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -5308,6 +5348,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5416,6 +5462,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5485,6 +5537,27 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
@@ -5627,6 +5700,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5729,6 +5808,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -5902,6 +5987,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -6446,6 +6540,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "description": "Transform AI conversation history into personalized guided meditations",
   "dependencies": {
+    "jszip": "^3.10.1",
     "next": "^16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ export default function Home() {
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
   const [hasElevenLabsKey, setHasElevenLabsKey] = useState(false);
   const [theme, setTheme] = useState<Theme>("minimalist");
+  const [importDate, setImportDate] = useState<string | null>(null);
 
   // Listen for theme changes
   useEffect(() => {
@@ -69,6 +70,7 @@ export default function Home() {
               const parsed = JSON.parse(storedMeditations) as Meditation[];
               if (parsed.length > 0) {
                 setMeditations(parsed);
+                setImportDate(localStorage.getItem("stillpoint-import-date"));
                 setStep("gallery");
                 return;
               }
@@ -98,6 +100,7 @@ export default function Home() {
               const parsed = JSON.parse(storedMeditations) as Meditation[];
               if (parsed.length > 0) {
                 setMeditations(parsed);
+                setImportDate(localStorage.getItem("stillpoint-import-date"));
                 setStep("gallery");
                 return;
               }
@@ -183,13 +186,16 @@ export default function Home() {
         return;
       }
 
-      // Cache meditations
+      // Cache meditations and import timestamp
       localStorage.setItem(
         "stillpoint-meditations",
         JSON.stringify(generated)
       );
+      const now = new Date().toISOString();
+      localStorage.setItem("stillpoint-import-date", now);
 
       setMeditations(generated);
+      setImportDate(now);
       setProcessing({ stage: "complete", message: "Your meditations are ready." });
       setStep("gallery");
     },
@@ -278,7 +284,9 @@ export default function Home() {
     localStorage.removeItem("stillpoint-conversations");
     localStorage.removeItem("stillpoint-meditations");
     localStorage.removeItem("stillpoint-extraction");
+    localStorage.removeItem("stillpoint-import-date");
     setMeditations([]);
+    setImportDate(null);
     setSelectedMeditation(null);
     setProcessing({ stage: "idle", message: "" });
 
@@ -327,6 +335,27 @@ export default function Home() {
         {step === "upload" && (
           <div className="space-y-6 fade-in">
             <UploadZone onFileLoaded={handleFileLoaded} />
+            <details className="text-xs text-ink/40">
+              <summary className="cursor-pointer hover:text-ink/60 transition-colors">
+                How to export from Claude
+              </summary>
+              <ol className="mt-2 space-y-1 pl-4 list-decimal text-ink/40">
+                <li>
+                  Go to{" "}
+                  <a
+                    href="https://claude.ai/settings"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-ink/60"
+                  >
+                    claude.ai/settings
+                  </a>
+                </li>
+                <li>Click &quot;Export Data&quot;</li>
+                <li>Check your email for the download link</li>
+                <li>Download the ZIP and drop it here</li>
+              </ol>
+            </details>
             <div className="flex items-center justify-between">
               {!serverHasKeys && (
                 <button
@@ -352,6 +381,46 @@ export default function Home() {
 
         {step === "gallery" && (
           <div className="fade-in space-y-4">
+            {importDate && (() => {
+              const days = Math.floor(
+                (Date.now() - new Date(importDate).getTime()) / 86_400_000
+              );
+              if (days > 30) {
+                return (
+                  <div className="flex items-center justify-between rounded-lg bg-amber-50/60 px-4 py-3 text-xs">
+                    <span className="text-amber-700/80">
+                      Your meditations are over a month old
+                    </span>
+                    <button
+                      onClick={() => setStep("upload")}
+                      className="font-medium text-amber-700 hover:text-amber-800 transition-colors underline"
+                    >
+                      Update
+                    </button>
+                  </div>
+                );
+              }
+              if (days >= 7) {
+                return (
+                  <div className="flex items-center justify-between rounded-lg bg-edge/30 px-4 py-3 text-xs">
+                    <span className="text-ink/40">
+                      Updated {days} days ago
+                    </span>
+                    <button
+                      onClick={() => setStep("upload")}
+                      className="text-ink/40 hover:text-ink/60 transition-colors underline"
+                    >
+                      Update
+                    </button>
+                  </div>
+                );
+              }
+              return (
+                <p className="text-center text-xs text-ink/30">
+                  Updated {days === 0 ? "today" : days === 1 ? "yesterday" : `${days} days ago`}
+                </p>
+              );
+            })()}
             {hasElevenLabsKey && (
               <VoiceSelector
                 selectedVoiceId={selectedVoiceId}

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import { extractConversationsFromZip } from "@/lib/extractZip";
+import {
+  findConversationsInEntries,
+  findConversationsInFileList,
+} from "@/lib/extractFromDirectory";
 
 interface UploadZoneProps {
   onFileLoaded: (data: Record<string, unknown>[]) => void;
@@ -10,46 +15,108 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
 
-  const processFile = useCallback(
+  const processJsonFile = useCallback(
     (file: File) => {
-      setError(null);
-
-      if (!file.name.endsWith(".json")) {
-        setError("Please upload a JSON file exported from Claude.");
-        return;
-      }
-
       setFileName(file.name);
-
       const reader = new FileReader();
       reader.onload = (e) => {
         try {
           const raw = JSON.parse(e.target?.result as string);
 
-          // Claude export is an array of conversation objects
           if (!Array.isArray(raw)) {
             setError(
               "This doesn't look like a Claude export. Expected a JSON array of conversations."
             );
+            setIsLoading(false);
             return;
           }
 
+          setIsLoading(false);
           onFileLoaded(raw);
         } catch {
           setError("Could not parse this file. Is it valid JSON?");
+          setIsLoading(false);
         }
       };
-      reader.onerror = () => setError("Failed to read file.");
+      reader.onerror = () => {
+        setError("Failed to read file.");
+        setIsLoading(false);
+      };
       reader.readAsText(file);
     },
     [onFileLoaded]
   );
 
-  function handleDrop(e: React.DragEvent) {
+  const processFile = useCallback(
+    async (file: File) => {
+      setError(null);
+      setIsLoading(true);
+
+      if (file.name.endsWith(".zip")) {
+        setFileName(file.name);
+        try {
+          const data = await extractConversationsFromZip(file);
+          setIsLoading(false);
+          onFileLoaded(data);
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to read ZIP file."
+          );
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      if (file.name.endsWith(".json")) {
+        processJsonFile(file);
+        return;
+      }
+
+      setError(
+        "Please upload a JSON or ZIP file exported from Claude."
+      );
+      setIsLoading(false);
+    },
+    [onFileLoaded, processJsonFile]
+  );
+
+  async function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     setIsDragging(false);
+    setError(null);
+
+    // Check if a directory was dropped
+    const items = e.dataTransfer.items;
+    if (items && items.length > 0) {
+      const firstEntry = items[0].webkitGetAsEntry?.();
+      if (firstEntry?.isDirectory) {
+        setIsLoading(true);
+        setFileName(firstEntry.name + "/");
+        try {
+          const data = await findConversationsInEntries(items);
+          if (data) {
+            setIsLoading(false);
+            onFileLoaded(data);
+            return;
+          }
+          setError(
+            "No conversations.json found in this folder. Make sure you're dropping an unzipped Claude export."
+          );
+        } catch {
+          setError("Failed to read folder contents.");
+        }
+        setIsLoading(false);
+        return;
+      }
+    }
+
+    // Regular file drop
     const file = e.dataTransfer.files[0];
     if (file) processFile(file);
   }
@@ -64,17 +131,41 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
     if (file) processFile(file);
   }
 
+  async function handleFolderSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    setError(null);
+    setIsLoading(true);
+    setFileName("Selected folder");
+
+    try {
+      const data = await findConversationsInFileList(files);
+      if (data) {
+        setIsLoading(false);
+        onFileLoaded(data);
+        return;
+      }
+      setError(
+        "No conversations.json found in this folder. Make sure you selected an unzipped Claude export."
+      );
+    } catch {
+      setError("Failed to read folder contents.");
+    }
+    setIsLoading(false);
+  }
+
   return (
     <div className="fade-in">
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragLeave={() => setIsDragging(false)}
-        onClick={() => inputRef.current?.click()}
+        onClick={() => fileInputRef.current?.click()}
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+          if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click();
         }}
         className={`cursor-pointer rounded-xl border-2 border-dashed p-6 sm:p-12 text-center transition-all active:scale-[0.98] ${
           isDragging
@@ -83,10 +174,18 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
         }`}
       >
         <input
-          ref={inputRef}
+          ref={fileInputRef}
           type="file"
-          accept=".json"
+          accept=".json,.zip"
           onChange={handleFileSelect}
+          className="hidden"
+        />
+        <input
+          ref={folderInputRef}
+          type="file"
+          // @ts-expect-error webkitdirectory is non-standard but widely supported
+          webkitdirectory=""
+          onChange={handleFolderSelect}
           className="hidden"
         />
 
@@ -106,7 +205,9 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
           </svg>
         </div>
 
-        {fileName ? (
+        {isLoading ? (
+          <p className="text-sm text-ink/60">Reading file...</p>
+        ) : fileName ? (
           <p className="text-sm text-accent">{fileName}</p>
         ) : (
           <>
@@ -115,10 +216,23 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
               <span className="sm:hidden">Tap to select your Claude export</span>
             </p>
             <p className="mt-1 text-xs text-ink/30">
-              JSON file from claude.ai &rarr; Settings &rarr; Export Data
+              ZIP or JSON file — or drop the unzipped folder
             </p>
           </>
         )}
+      </div>
+
+      <div className="mt-2 text-center">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            folderInputRef.current?.click();
+          }}
+          className="text-xs text-ink/30 transition-colors hover:text-ink/50 underline"
+        >
+          Or select a folder
+        </button>
       </div>
 
       {error && (

--- a/src/lib/extractFromDirectory.ts
+++ b/src/lib/extractFromDirectory.ts
@@ -1,0 +1,93 @@
+/**
+ * Traverses a dropped directory (via webkitGetAsEntry) to find conversations.json.
+ * Returns the parsed JSON array, or null if not found.
+ */
+
+function readEntriesPromise(
+  reader: FileSystemDirectoryReader
+): Promise<FileSystemEntry[]> {
+  return new Promise((resolve, reject) => {
+    reader.readEntries(resolve, reject);
+  });
+}
+
+function fileFromEntry(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, reject);
+  });
+}
+
+async function findFileInDirectory(
+  dirEntry: FileSystemDirectoryEntry,
+  targetName: string
+): Promise<File | null> {
+  const reader = dirEntry.createReader();
+  let allEntries: FileSystemEntry[] = [];
+
+  // readEntries may return results in batches
+  let batch = await readEntriesPromise(reader);
+  while (batch.length > 0) {
+    allEntries = allEntries.concat(batch);
+    batch = await readEntriesPromise(reader);
+  }
+
+  for (const entry of allEntries) {
+    if (entry.isFile && entry.name === targetName) {
+      return fileFromEntry(entry as FileSystemFileEntry);
+    }
+    if (entry.isDirectory) {
+      const found = await findFileInDirectory(
+        entry as FileSystemDirectoryEntry,
+        targetName
+      );
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+export async function findConversationsInEntries(
+  items: DataTransferItemList
+): Promise<Record<string, unknown>[] | null> {
+  for (let i = 0; i < items.length; i++) {
+    const entry = items[i].webkitGetAsEntry();
+    if (!entry) continue;
+
+    if (entry.isDirectory) {
+      const file = await findFileInDirectory(
+        entry as FileSystemDirectoryEntry,
+        "conversations.json"
+      );
+      if (file) {
+        const text = await file.text();
+        const parsed: unknown = JSON.parse(text);
+        if (Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>[];
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Finds conversations.json in a FileList from a webkitdirectory input.
+ * The browser flattens the directory structure into a flat file list.
+ */
+export async function findConversationsInFileList(
+  files: FileList
+): Promise<Record<string, unknown>[] | null> {
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.name === "conversations.json") {
+      const text = await file.text();
+      const parsed: unknown = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>[];
+      }
+    }
+  }
+  return null;
+}

--- a/src/lib/extractZip.ts
+++ b/src/lib/extractZip.ts
@@ -1,0 +1,44 @@
+import JSZip from "jszip";
+
+/**
+ * Extracts conversations.json from a Claude data export ZIP file.
+ * Searches all entries by basename so it works regardless of folder nesting.
+ */
+export async function extractConversationsFromZip(
+  file: File
+): Promise<Record<string, unknown>[]> {
+  const zip = await JSZip.loadAsync(file);
+
+  // Find conversations.json anywhere in the archive
+  let conversationsFile: JSZip.JSZipObject | null = null;
+  zip.forEach((relativePath, entry) => {
+    if (!entry.dir && relativePath.split("/").pop() === "conversations.json") {
+      conversationsFile = entry;
+    }
+  });
+
+  if (!conversationsFile) {
+    throw new Error(
+      "No conversations.json found in this ZIP. Make sure you're uploading a Claude data export."
+    );
+  }
+
+  const text = await (conversationsFile as JSZip.JSZipObject).async("string");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(
+      "conversations.json in the ZIP is not valid JSON."
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "conversations.json doesn't contain the expected array of conversations."
+    );
+  }
+
+  return parsed as Record<string, unknown>[];
+}

--- a/src/types/filesystem.d.ts
+++ b/src/types/filesystem.d.ts
@@ -1,0 +1,30 @@
+/** Minimal type declarations for the File System Access API (webkitGetAsEntry). */
+
+interface FileSystemEntry {
+  readonly isFile: boolean;
+  readonly isDirectory: boolean;
+  readonly name: string;
+}
+
+interface FileSystemFileEntry extends FileSystemEntry {
+  readonly isFile: true;
+  readonly isDirectory: false;
+  file(successCallback: (file: File) => void, errorCallback?: (err: DOMException) => void): void;
+}
+
+interface FileSystemDirectoryEntry extends FileSystemEntry {
+  readonly isFile: false;
+  readonly isDirectory: true;
+  createReader(): FileSystemDirectoryReader;
+}
+
+interface FileSystemDirectoryReader {
+  readEntries(
+    successCallback: (entries: FileSystemEntry[]) => void,
+    errorCallback?: (err: DOMException) => void
+  ): void;
+}
+
+interface DataTransferItem {
+  webkitGetAsEntry(): FileSystemEntry | null;
+}


### PR DESCRIPTION
Accept ZIP files directly from Claude's data export (no manual unzipping needed),
support dropping unzipped folders, track import freshness in the gallery with
contextual update prompts, and add "How to export from Claude" instructions.

- Add jszip dependency for client-side ZIP extraction
- Create extractZip.ts to find and parse conversations.json inside ZIPs
- Create extractFromDirectory.ts for folder drag-and-drop + webkitdirectory
- Add FileSystem API type declarations for directory traversal
- Update UploadZone to handle .zip, .json, and folder drops
- Add import date tracking to localStorage with freshness indicators
- Add collapsible export guide with direct link to claude.ai/settings

https://claude.ai/code/session_01ThMgJ81LEqJm4HRDmHRjvf