### PR TITLE
Mobile-optimize upload flow and layout for iPhone use

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="min-h-screen bg-surface text-ink antialiased">
-        <main className="mx-auto max-w-3xl px-6 py-12">{children}</main>
+        <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-12">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -302,11 +302,11 @@ export default function Home() {
 
       {/* Header — always visible except in player */}
       {step !== "reader" && (
-        <div className="mb-12 text-center fade-in">
+        <div className="mb-8 sm:mb-12 text-center fade-in">
           <div className="flex justify-end mb-4">
             <ThemeSelector />
           </div>
-          <h1 className="font-display text-5xl font-light tracking-tight text-ink">
+          <h1 className="font-display text-4xl sm:text-5xl font-light tracking-tight text-ink">
             stillpoint
           </h1>
           <p className="mt-3 text-sm text-ink/50">

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -76,7 +76,7 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
         }}
-        className={`cursor-pointer rounded-xl border-2 border-dashed p-12 text-center transition-all ${
+        className={`cursor-pointer rounded-xl border-2 border-dashed p-6 sm:p-12 text-center transition-all active:scale-[0.98] ${
           isDragging
             ? "border-accent bg-accent/5"
             : "border-edge hover:border-accent/50"
@@ -111,10 +111,11 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
         ) : (
           <>
             <p className="text-sm font-medium text-ink/60">
-              Drop your Claude export here
+              <span className="hidden sm:inline">Drop your Claude export here or click to browse</span>
+              <span className="sm:hidden">Tap to select your Claude export</span>
             </p>
             <p className="mt-1 text-xs text-ink/30">
-              JSON file from claude.ai → Settings → Export Data
+              JSON file from claude.ai &rarr; Settings &rarr; Export Data
             </p>
           </>
         )}


### PR DESCRIPTION
- Responsive padding on UploadZone (p-6 on mobile, p-12 on desktop)
- Show "Tap to select" on mobile instead of "Drop your export here"
- Add active:scale feedback for touch interaction
- Reduce header/layout spacing on small screens

https://claude.ai/code/session_01FfHJztwQsDTXrhqirpy4zq