### PR TITLE
Rename CSS color tokens to semantic names

### DIFF
--- a/.claude/skills/theme-designer/SKILL.md
+++ b/.claude/skills/theme-designer/SKILL.md
@@ -30,12 +30,12 @@ define all 6 color variables:
 
 ```css
 .theme-{name} {
-  --color-cream:     /* Background */
-  --color-charcoal:  /* Primary text */
-  --color-sage:      /* Accent, interactive elements */
-  --color-clay:      /* Secondary accent */
-  --color-mist:      /* Borders, subtle UI */
-  --color-deep:      /* Hover states, emphasis */
+  --color-surface:   /* Background */
+  --color-ink:       /* Primary text */
+  --color-accent:    /* Accent, interactive elements */
+  --color-warm:      /* Secondary accent */
+  --color-edge:      /* Borders, subtle UI */
+  --color-emphasis:  /* Hover states, emphasis */
 }
 ```
 
@@ -88,22 +88,22 @@ a `{Name}Background.tsx` component and conditionally render it in
 
 ## Design Constraints
 
-- **Contrast:** Background (`--color-cream`) and text (`--color-charcoal`)
+- **Contrast:** Background (`--color-surface`) and text (`--color-ink`)
   must meet WCAG AA contrast ratio (4.5:1 minimum). The player view is
   full-screen — the theme must remain readable at that scale.
-- **Accent visibility:** `--color-sage` is used on interactive elements
+- **Accent visibility:** `--color-accent` is used on interactive elements
   (buttons, focus rings, badges). It must be clearly visible against
-  both `--color-cream` and white/transparent card backgrounds.
+  both `--color-surface` and white/transparent card backgrounds.
 - **Transition:** The app applies `transition: background-color 0.5s ease`
   on body. Avoid colors that flash harshly during theme switches.
 - **No hard-coded colors in components.** Components use Tailwind classes
-  like `bg-cream`, `text-charcoal`, `border-mist`. If a component has a
+  like `bg-surface`, `text-ink`, `border-edge`. If a component has a
   raw hex value, it won't respond to theme changes.
 
 ## Existing Themes
 
-- **Minimalist** (default) — Warm cream/sage/charcoal. No background
-  effects. Cards are `bg-white/40`. See `docs/themes/minimalist.md`.
+- **Minimalist** (default) — Warm neutrals. No background effects.
+  Cards are `bg-white/40`. See `docs/themes/minimalist.md`.
 - **Aura** — Lavender/pink/mint with floating gradient blobs and frosted
   glass cards. Uses `AuraBackground.tsx` + `.theme-aura .aura-*` classes.
   See `docs/themes/aura.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Next.js 16 (App Router) · TypeScript strict · Tailwind CSS 4 · Claude API (So
 
 Users choose between themes via a pill selector (`ThemeSelector.tsx`). Themes work by overriding Tailwind's `--color-*` CSS variables on `<html>` via `.theme-{name}` classes. All defined in `src/styles/globals.css`.
 
-- **[Minimalist](docs/themes/minimalist.md)** — Warm minimalism, cream/sage/charcoal. Default.
+- **[Minimalist](docs/themes/minimalist.md)** — Warm minimalism. Default. Tokens: surface/ink/accent/warm/edge/emphasis.
 - **[Aura](docs/themes/aura.md)** — Iridescent gradient blobs, frosted glass, lavender/pink/mint.
 
 To add a new theme: add entry to `THEMES` array in `ThemeSelector.tsx`, add `--color-*` overrides under `.theme-{name}` in `globals.css`, create `docs/themes/{name}.md`.

--- a/docs/themes/aura.md
+++ b/docs/themes/aura.md
@@ -5,12 +5,12 @@ Iridescent gradients, frosted glass, soft ethereal glow. Inspired by abstract au
 ## Colors
 
 ```css
---color-cream:     #F8F4FF;    /* Background — soft lavender white */
---color-charcoal:  #2D2640;    /* Primary text — deep purple-grey */
---color-sage:      #9B8EC4;    /* Accent — soft purple */
---color-clay:      #D4A0C0;    /* Secondary accent — dusty rose */
---color-mist:      #E8E0F0;    /* Borders — lavender mist */
---color-deep:      #1C1528;    /* Hover states — deep violet */
+--color-surface:   #F8F4FF;    /* Background — soft lavender white */
+--color-ink:       #2D2640;    /* Primary text — deep purple-grey */
+--color-accent:    #9B8EC4;    /* Accent — soft purple */
+--color-warm:      #D4A0C0;    /* Secondary accent — dusty rose */
+--color-edge:      #E8E0F0;    /* Borders — lavender mist */
+--color-emphasis:  #1C1528;    /* Hover states — deep violet */
 ```
 
 ## Background

--- a/docs/themes/minimalist.md
+++ b/docs/themes/minimalist.md
@@ -5,12 +5,12 @@ Default theme. Warm minimalism — Kinfolk magazine meets high-end therapy offic
 ## Colors
 
 ```css
---color-cream:     #F5F0EB;    /* Background */
---color-charcoal:  #2C2C2C;    /* Primary text */
---color-sage:      #8B9D83;    /* Accent, interactive */
---color-clay:      #C4A882;    /* Secondary accent */
---color-mist:      #D4D0CB;    /* Borders, subtle UI */
---color-deep:      #1A1A1A;    /* Hover states */
+--color-surface:   #F5F0EB;    /* Background */
+--color-ink:       #2C2C2C;    /* Primary text */
+--color-accent:    #8B9D83;    /* Accent, interactive */
+--color-warm:      #C4A882;    /* Secondary accent */
+--color-edge:      #D4D0CB;    /* Borders, subtle UI */
+--color-emphasis:  #1A1A1A;    /* Hover states */
 ```
 
 ## Typography
@@ -27,12 +27,12 @@ Default theme. Warm minimalism — Kinfolk magazine meets high-end therapy offic
 
 ## Component Styling
 
-- **Cards:** `bg-white/40 border border-mist`, subtle hover lift
-- **Inputs:** `bg-white/50 border border-mist`, sage focus ring
-- **Buttons:** `bg-charcoal text-cream`, darkens on hover
-- **Breathing circle:** Solid sage with scale/opacity animation
-- **Badges:** `bg-sage/10 text-sage`
+- **Cards:** `bg-white/40 border border-edge`, subtle hover lift
+- **Inputs:** `bg-white/50 border border-edge`, accent focus ring
+- **Buttons:** `bg-ink text-surface`, darkens on hover
+- **Breathing circle:** Solid accent with scale/opacity animation
+- **Badges:** `bg-accent/10 text-accent`
 
 ## CSS Class
 
-Applied via `theme-minimalist` on `<html>`. This is the default — no variable overrides needed, uses the `@theme` values directly.
+Applied via `theme-minimalist` on `<html>`. This is the default — no variable overrides needed, uses the `@theme` values directly. Tokens: `surface`, `ink`, `accent`, `warm`, `edge`, `emphasis`.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body className="min-h-screen bg-cream text-charcoal antialiased">
+      <body className="min-h-screen bg-surface text-ink antialiased">
         <main className="mx-auto max-w-3xl px-6 py-12">{children}</main>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -306,10 +306,10 @@ export default function Home() {
           <div className="flex justify-end mb-4">
             <ThemeSelector />
           </div>
-          <h1 className="font-display text-5xl font-light tracking-tight text-charcoal">
+          <h1 className="font-display text-5xl font-light tracking-tight text-ink">
             stillpoint
           </h1>
-          <p className="mt-3 text-sm text-charcoal/50">
+          <p className="mt-3 text-sm text-ink/50">
             Your conversations, transformed into meditations.
           </p>
         </div>
@@ -331,14 +331,14 @@ export default function Home() {
               {!serverHasKeys && (
                 <button
                   onClick={() => setStep("keys")}
-                  className="text-xs text-charcoal/30 transition-colors hover:text-charcoal/60"
+                  className="text-xs text-ink/30 transition-colors hover:text-ink/60"
                 >
                   Change API keys
                 </button>
               )}
               <button
                 onClick={handleClearData}
-                className="text-xs text-charcoal/30 transition-colors hover:text-red-400 ml-auto"
+                className="text-xs text-ink/30 transition-colors hover:text-red-400 ml-auto"
               >
                 Clear all data
               </button>
@@ -369,13 +369,13 @@ export default function Home() {
             <div className="flex items-center justify-between pt-4">
               <button
                 onClick={() => setStep("upload")}
-                className="text-xs text-charcoal/30 transition-colors hover:text-charcoal/60"
+                className="text-xs text-ink/30 transition-colors hover:text-ink/60"
               >
                 Upload new conversations
               </button>
               <button
                 onClick={handleClearData}
-                className="text-xs text-charcoal/30 transition-colors hover:text-red-400"
+                className="text-xs text-ink/30 transition-colors hover:text-red-400"
               >
                 Clear all data
               </button>

--- a/src/components/ApiKeySetup.tsx
+++ b/src/components/ApiKeySetup.tsx
@@ -38,10 +38,10 @@ export default function ApiKeySetup({
       <div>
         <label
           htmlFor="anthropic-key"
-          className="mb-2 block text-sm font-medium text-charcoal/70"
+          className="mb-2 block text-sm font-medium text-ink/70"
         >
           Anthropic API Key
-          <span className="ml-1 text-clay">*</span>
+          <span className="ml-1 text-warm">*</span>
         </label>
         <input
           id="anthropic-key"
@@ -49,16 +49,16 @@ export default function ApiKeySetup({
           value={anthropicKey}
           onChange={(e) => setAnthropicKey(e.target.value)}
           placeholder="sk-ant-..."
-          className="w-full rounded-lg border border-mist bg-white/50 px-4 py-3 text-sm transition-colors placeholder:text-charcoal/30 focus:border-sage focus:outline-none aura-input"
+          className="w-full rounded-lg border border-edge bg-white/50 px-4 py-3 text-sm transition-colors placeholder:text-ink/30 focus:border-accent focus:outline-none aura-input"
           required
         />
-        <p className="mt-1.5 text-xs text-charcoal/40">
+        <p className="mt-1.5 text-xs text-ink/40">
           Get yours at{" "}
           <a
             href="https://console.anthropic.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline transition-colors hover:text-sage"
+            className="underline transition-colors hover:text-accent"
           >
             console.anthropic.com
           </a>
@@ -69,10 +69,10 @@ export default function ApiKeySetup({
         <div className="fade-in">
           <label
             htmlFor="elevenlabs-key"
-            className="mb-2 block text-sm font-medium text-charcoal/70"
+            className="mb-2 block text-sm font-medium text-ink/70"
           >
             ElevenLabs API Key
-            <span className="ml-1 text-xs text-charcoal/40">(optional)</span>
+            <span className="ml-1 text-xs text-ink/40">(optional)</span>
           </label>
           <input
             id="elevenlabs-key"
@@ -80,9 +80,9 @@ export default function ApiKeySetup({
             value={elevenLabsKey}
             onChange={(e) => setElevenLabsKey(e.target.value)}
             placeholder="xi-..."
-            className="w-full rounded-lg border border-mist bg-white/50 px-4 py-3 text-sm transition-colors placeholder:text-charcoal/30 focus:border-sage focus:outline-none aura-input"
+            className="w-full rounded-lg border border-edge bg-white/50 px-4 py-3 text-sm transition-colors placeholder:text-ink/30 focus:border-accent focus:outline-none aura-input"
           />
-          <p className="mt-1.5 text-xs text-charcoal/40">
+          <p className="mt-1.5 text-xs text-ink/40">
             For audio playback. Without this, meditations are text-only.
           </p>
         </div>
@@ -90,7 +90,7 @@ export default function ApiKeySetup({
         <button
           type="button"
           onClick={() => setShowElevenLabs(true)}
-          className="text-sm text-charcoal/40 transition-colors hover:text-sage"
+          className="text-sm text-ink/40 transition-colors hover:text-accent"
         >
           + Add ElevenLabs key for audio
         </button>
@@ -99,7 +99,7 @@ export default function ApiKeySetup({
       <button
         type="submit"
         disabled={!anthropicKey.trim()}
-        className="w-full rounded-lg bg-charcoal px-6 py-3 text-sm font-medium text-cream transition-all hover:bg-deep disabled:cursor-not-allowed disabled:opacity-30 aura-btn"
+        className="w-full rounded-lg bg-ink px-6 py-3 text-sm font-medium text-surface transition-all hover:bg-emphasis disabled:cursor-not-allowed disabled:opacity-30 aura-btn"
       >
         Continue
       </button>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -172,7 +172,7 @@ function WebSpeechPlayer({ script }: { script: string }) {
 
   if (!supported) {
     return (
-      <p className="text-center text-xs text-charcoal/30">
+      <p className="text-center text-xs text-ink/30">
         Audio playback not supported in this browser.
       </p>
     );
@@ -180,11 +180,11 @@ function WebSpeechPlayer({ script }: { script: string }) {
 
   return (
     <div className="fade-in space-y-3">
-      <div className="rounded-xl border border-mist bg-white/40 p-4">
+      <div className="rounded-xl border border-edge bg-white/40 p-4">
         <div className="flex items-center gap-4">
           <button
             onClick={togglePlay}
-            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-charcoal text-cream transition-all hover:bg-deep"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-all hover:bg-emphasis"
           >
             {isPlaying ? (
               <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
@@ -199,7 +199,7 @@ function WebSpeechPlayer({ script }: { script: string }) {
           </button>
 
           <div className="flex-1">
-            <p className="text-xs text-charcoal/40">
+            <p className="text-xs text-ink/40">
               {isPlaying ? "Playing with browser voice..." : "Browser text-to-speech"}
             </p>
           </div>
@@ -214,7 +214,7 @@ function WebSpeechPlayer({ script }: { script: string }) {
                   setIsPlaying(false);
                 }
               }}
-              className="rounded-lg border border-mist bg-white/50 px-2 py-1 text-xs text-charcoal/60"
+              className="rounded-lg border border-edge bg-white/50 px-2 py-1 text-xs text-ink/60"
             >
               {voices.map((v, i) => (
                 <option key={v.name} value={i}>
@@ -225,7 +225,7 @@ function WebSpeechPlayer({ script }: { script: string }) {
           )}
         </div>
       </div>
-      <p className="text-center text-xs text-charcoal/25">
+      <p className="text-center text-xs text-ink/25">
         Add an ElevenLabs paid key for higher-quality voices
       </p>
     </div>
@@ -255,12 +255,12 @@ function PlayerShell({
   onCycleSpeed: () => void;
 }) {
   return (
-    <div className="fade-in rounded-xl border border-mist bg-white/40 p-4">
+    <div className="fade-in rounded-xl border border-edge bg-white/40 p-4">
       <div className="flex items-center gap-4">
         <button
           onClick={onTogglePlay}
           disabled={disabled}
-          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-charcoal text-cream transition-all hover:bg-deep disabled:opacity-30"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-all hover:bg-emphasis disabled:opacity-30"
         >
           {isPlaying ? (
             <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
@@ -282,12 +282,12 @@ function PlayerShell({
             step={0.1}
             value={currentTime}
             onChange={onSeek}
-            className="h-1 w-full cursor-pointer appearance-none rounded-full bg-mist accent-sage"
+            className="h-1 w-full cursor-pointer appearance-none rounded-full bg-edge accent-accent"
             style={{
-              background: `linear-gradient(to right, var(--sage) ${progress}%, var(--mist) ${progress}%)`,
+              background: `linear-gradient(to right, var(--accent) ${progress}%, var(--edge) ${progress}%)`,
             }}
           />
-          <div className="flex justify-between text-xs text-charcoal/30">
+          <div className="flex justify-between text-xs text-ink/30">
             <span>{formatTime(currentTime)}</span>
             <span>{formatTime(duration)}</span>
           </div>
@@ -295,7 +295,7 @@ function PlayerShell({
 
         <button
           onClick={onCycleSpeed}
-          className="shrink-0 rounded-full border border-mist px-2.5 py-1 text-xs text-charcoal/40 transition-colors hover:border-sage hover:text-charcoal/60"
+          className="shrink-0 rounded-full border border-edge px-2.5 py-1 text-xs text-ink/40 transition-colors hover:border-accent hover:text-ink/60"
         >
           {SPEEDS[speedIndex]}x
         </button>

--- a/src/components/BreathGuide.tsx
+++ b/src/components/BreathGuide.tsx
@@ -121,7 +121,7 @@ export default function BreathGuide({
         aria-label={active ? "Stop breathing guide" : "Start breathing guide"}
       >
         <div
-          className={`${circleSize} rounded-full bg-sage transition-all duration-1000 ease-in-out`}
+          className={`${circleSize} rounded-full bg-accent transition-all duration-1000 ease-in-out`}
           style={{
             transform: `scale(${getScale()})`,
             opacity: getOpacity(),
@@ -129,21 +129,21 @@ export default function BreathGuide({
         />
         <div className="absolute flex flex-col items-center">
           {phase === "idle" ? (
-            <span className={`${textSize} text-charcoal/60`}>
+            <span className={`${textSize} text-ink/60`}>
               Box
             </span>
           ) : (
-            <span className={`${countdownSize} font-light text-charcoal/80`}>
+            <span className={`${countdownSize} font-light text-ink/80`}>
               {countdown}
             </span>
           )}
         </div>
       </button>
 
-      <span className={`${textSize} font-light tracking-wide text-charcoal/50`}>
+      <span className={`${textSize} font-light tracking-wide text-ink/50`}>
         {PHASE_LABELS[phase]}
         {active && cycleCount > 0 && phase === "inhale" && countdown === PHASE_DURATIONS.inhale && (
-          <span className="ml-2 text-charcoal/30">· cycle {cycleCount + 1}</span>
+          <span className="ml-2 text-ink/30">· cycle {cycleCount + 1}</span>
         )}
       </span>
     </div>

--- a/src/components/MeditationCard.tsx
+++ b/src/components/MeditationCard.tsx
@@ -28,25 +28,25 @@ export default function MeditationCard({
   return (
     <button
       onClick={() => onSelect(meditation)}
-      className="fade-in group w-full rounded-xl border border-mist bg-white/40 p-6 text-left transition-all hover:border-sage/50 hover:bg-white/60 aura-glass"
+      className="fade-in group w-full rounded-xl border border-edge bg-white/40 p-6 text-left transition-all hover:border-accent/50 hover:bg-white/60 aura-glass"
     >
       <div className="mb-3 flex items-start justify-between">
-        <h3 className="font-display text-2xl font-light text-charcoal">
+        <h3 className="font-display text-2xl font-light text-ink">
           {meditation.title}
         </h3>
-        <span className="ml-3 shrink-0 rounded-full bg-sage/10 px-2.5 py-0.5 text-xs text-sage">
+        <span className="ml-3 shrink-0 rounded-full bg-accent/10 px-2.5 py-0.5 text-xs text-accent">
           {displayInfo.name}
         </span>
       </div>
 
-      <p className="text-sm leading-relaxed text-charcoal/50">
+      <p className="text-sm leading-relaxed text-ink/50">
         {meditation.capacity}
       </p>
 
-      <div className="mt-4 flex items-center gap-3 text-xs text-charcoal/30">
+      <div className="mt-4 flex items-center gap-3 text-xs text-ink/30">
         <span>{meditation.duration} min</span>
         <span>·</span>
-        <span className="transition-colors group-hover:text-sage">
+        <span className="transition-colors group-hover:text-accent">
           Read meditation →
         </span>
       </div>

--- a/src/components/MeditationPlayer.tsx
+++ b/src/components/MeditationPlayer.tsx
@@ -215,7 +215,7 @@ export default function MeditationPlayer({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col bg-cream transition-colors"
+      className="fixed inset-0 z-50 flex flex-col bg-surface transition-colors"
       onMouseMove={handleInteraction}
       onTouchStart={handleInteraction}
     >
@@ -227,7 +227,7 @@ export default function MeditationPlayer({
       >
         <button
           onClick={onBack}
-          className="flex items-center gap-2 text-sm text-charcoal/40 transition-colors hover:text-charcoal/70"
+          className="flex items-center gap-2 text-sm text-ink/40 transition-colors hover:text-ink/70"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
             <path d="M19 12H5m0 0l7 7m-7-7l7-7" strokeLinecap="round" strokeLinejoin="round" />
@@ -244,8 +244,8 @@ export default function MeditationPlayer({
             }}
             className={`rounded-full px-3 py-1.5 text-xs transition-all ${
               showBreathGuide
-                ? "bg-sage/20 text-sage"
-                : "text-charcoal/30 hover:text-charcoal/50"
+                ? "bg-accent/20 text-accent"
+                : "text-ink/30 hover:text-ink/50"
             }`}
           >
             Breathe
@@ -259,8 +259,8 @@ export default function MeditationPlayer({
             }}
             className={`rounded-full px-3 py-1.5 text-xs transition-all ${
               showTimer
-                ? "bg-sage/20 text-sage"
-                : "text-charcoal/30 hover:text-charcoal/50"
+                ? "bg-accent/20 text-accent"
+                : "text-ink/30 hover:text-ink/50"
             }`}
           >
             Timer
@@ -272,13 +272,13 @@ export default function MeditationPlayer({
       <div className="flex flex-1 flex-col items-center overflow-hidden px-6">
         {/* Header */}
         <div className="mb-6 text-center">
-          <span className="mb-2 inline-block rounded-full bg-sage/10 px-2.5 py-0.5 text-xs text-sage">
+          <span className="mb-2 inline-block rounded-full bg-accent/10 px-2.5 py-0.5 text-xs text-accent">
             {displayInfo.name}
           </span>
-          <h2 className="font-display text-3xl font-light text-charcoal sm:text-4xl">
+          <h2 className="font-display text-3xl font-light text-ink sm:text-4xl">
             {meditation.title}
           </h2>
-          <p className="mt-2 text-sm text-charcoal/40">
+          <p className="mt-2 text-sm text-ink/40">
             {meditation.capacity}
           </p>
         </div>
@@ -316,13 +316,13 @@ export default function MeditationPlayer({
           className="flex-1 overflow-y-auto pb-32 scrollbar-hide"
           style={{ maxWidth: "36rem" }}
         >
-          <div className="font-display text-lg font-light leading-[2] text-charcoal/80 sm:text-xl sm:leading-[2.1]">
+          <div className="font-display text-lg font-light leading-[2] text-ink/80 sm:text-xl sm:leading-[2.1]">
             {segments.map((seg, i) => {
               if (seg.type === "pause") {
                 return (
                   <span
                     key={i}
-                    className="my-6 block text-center text-xs tracking-widest text-sage/50"
+                    className="my-6 block text-center text-xs tracking-widest text-accent/50"
                   >
                     · · · {seg.seconds}s · · ·
                   </span>
@@ -332,7 +332,7 @@ export default function MeditationPlayer({
                 return (
                   <span
                     key={i}
-                    className="my-6 block text-center text-xs tracking-widest text-sage"
+                    className="my-6 block text-center text-xs tracking-widest text-accent"
                   >
                     ○ breathe ○
                   </span>
@@ -342,7 +342,7 @@ export default function MeditationPlayer({
                 return (
                   <span
                     key={i}
-                    className="my-8 block text-center text-sm tracking-widest text-clay"
+                    className="my-8 block text-center text-sm tracking-widest text-warm"
                   >
                     ◊
                   </span>
@@ -364,7 +364,7 @@ export default function MeditationPlayer({
 
       {/* Bottom audio controls */}
       <div
-        className={`border-t border-mist/50 bg-cream/90 px-6 py-4 backdrop-blur-sm transition-all duration-500 ${
+        className={`border-t border-edge/50 bg-surface/90 px-6 py-4 backdrop-blur-sm transition-all duration-500 ${
           showControls || !isPlaying ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
         }`}
       >
@@ -374,7 +374,7 @@ export default function MeditationPlayer({
             <button
               onClick={togglePlay}
               disabled={!isAudioLoaded}
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-charcoal text-cream transition-all hover:bg-deep disabled:opacity-30"
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-all hover:bg-emphasis disabled:opacity-30"
             >
               {isPlaying ? (
                 <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
@@ -397,14 +397,14 @@ export default function MeditationPlayer({
                 step={0.1}
                 value={currentTime}
                 onChange={handleSeek}
-                className="h-1 w-full cursor-pointer appearance-none rounded-full bg-mist accent-sage"
+                className="h-1 w-full cursor-pointer appearance-none rounded-full bg-edge accent-accent"
                 style={{
-                  background: `linear-gradient(to right, var(--sage) ${progress}%, ${
-                    "var(--mist)"
+                  background: `linear-gradient(to right, var(--accent) ${progress}%, ${
+                    "var(--edge)"
                   } ${progress}%)`,
                 }}
               />
-              <div className="flex justify-between text-xs tabular-nums text-charcoal/30">
+              <div className="flex justify-between text-xs tabular-nums text-ink/30">
                 <span>{formatTime(currentTime)}</span>
                 <span>{formatTime(duration)}</span>
               </div>
@@ -413,7 +413,7 @@ export default function MeditationPlayer({
             {/* Speed */}
             <button
               onClick={cycleSpeed}
-              className="shrink-0 rounded-full border border-mist px-2.5 py-1 text-xs text-charcoal/40 transition-colors hover:border-sage hover:text-charcoal/60"
+              className="shrink-0 rounded-full border border-edge px-2.5 py-1 text-xs text-ink/40 transition-colors hover:border-accent hover:text-ink/60"
             >
               {SPEEDS[speedIndex]}x
             </button>
@@ -425,7 +425,7 @@ export default function MeditationPlayer({
                 <button
                   onClick={generateAudio}
                   disabled={isGeneratingAudio}
-                  className="w-full rounded-xl border border-mist bg-white/40 px-4 py-3 text-sm text-charcoal/60 transition-all hover:border-sage hover:text-charcoal disabled:opacity-50"
+                  className="w-full rounded-xl border border-edge bg-white/40 px-4 py-3 text-sm text-ink/60 transition-all hover:border-accent hover:text-ink disabled:opacity-50"
                 >
                   {isGeneratingAudio
                     ? "Generating audio..."

--- a/src/components/ProcessingView.tsx
+++ b/src/components/ProcessingView.tsx
@@ -46,13 +46,13 @@ export default function ProcessingView({ state, onRetry }: ProcessingViewProps) 
           state.stage === "error"
             ? "bg-red-200/40"
             : state.stage === "complete"
-              ? "bg-sage/30"
-              : "bg-sage/20 breathing-circle"
+              ? "bg-accent/30"
+              : "bg-accent/20 breathing-circle"
         }`}
       />
 
       {/* Stage message */}
-      <p className="mt-8 font-display text-xl font-light text-charcoal/70">
+      <p className="mt-8 font-display text-xl font-light text-ink/70">
         {state.message || STAGE_MESSAGES[state.stage]}
         {isActive && <span className="inline-block w-6 text-left">{dots}</span>}
       </p>
@@ -69,7 +69,7 @@ export default function ProcessingView({ state, onRetry }: ProcessingViewProps) 
               <div
                 key={stage}
                 className={`h-1.5 w-12 rounded-full transition-all duration-500 ${
-                  isCurrentOrPast ? "bg-sage" : "bg-mist"
+                  isCurrentOrPast ? "bg-accent" : "bg-edge"
                 }`}
               />
             );
@@ -84,7 +84,7 @@ export default function ProcessingView({ state, onRetry }: ProcessingViewProps) 
           {onRetry && (
             <button
               onClick={onRetry}
-              className="mt-4 rounded-lg border border-mist px-4 py-2 text-sm text-charcoal/60 transition-colors hover:border-sage hover:text-charcoal"
+              className="mt-4 rounded-lg border border-edge px-4 py-2 text-sm text-ink/60 transition-colors hover:border-accent hover:text-ink"
             >
               Try again
             </button>
@@ -94,7 +94,7 @@ export default function ProcessingView({ state, onRetry }: ProcessingViewProps) 
 
       {/* Complete state */}
       {state.stage === "complete" && (
-        <p className="mt-2 text-sm text-charcoal/40">
+        <p className="mt-2 text-sm text-ink/40">
           Scroll down to see your meditations.
         </p>
       )}

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -45,15 +45,15 @@ export default function ThemeSelector({ className = "" }: ThemeSelectorProps) {
   if (!mounted) return null;
 
   return (
-    <div className={`inline-flex rounded-full border border-mist bg-white/50 p-0.5 ${className}`}>
+    <div className={`inline-flex rounded-full border border-edge bg-white/50 p-0.5 ${className}`}>
       {THEMES.map((t) => (
         <button
           key={t.id}
           onClick={() => select(t.id)}
           className={`rounded-full px-3 py-1 text-xs transition-all ${
             theme === t.id
-              ? "bg-charcoal text-cream shadow-sm"
-              : "text-charcoal/40 hover:text-charcoal/70"
+              ? "bg-ink text-surface shadow-sm"
+              : "text-ink/40 hover:text-ink/70"
           }`}
         >
           {t.icon} {t.label}

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -77,22 +77,22 @@ export default function Timer({
     return (
       <button
         onClick={handleClick}
-        className="flex items-center gap-2 rounded-full px-2 py-1 transition-colors hover:bg-sage/10"
+        className="flex items-center gap-2 rounded-full px-2 py-1 transition-colors hover:bg-accent/10"
       >
-        <span className="text-xs tabular-nums text-charcoal/40">
+        <span className="text-xs tabular-nums text-ink/40">
           {isComplete ? "Reset" : formatTimer(remaining)}
         </span>
-        <div className="h-0.5 w-16 overflow-hidden rounded-full bg-mist">
+        <div className="h-0.5 w-16 overflow-hidden rounded-full bg-edge">
           <div
-            className="h-full rounded-full bg-sage transition-all duration-1000"
+            className="h-full rounded-full bg-accent transition-all duration-1000"
             style={{ width: `${progress * 100}%` }}
           />
         </div>
         {!isRunning && !isComplete && (
-          <span className="text-xs text-sage">▶</span>
+          <span className="text-xs text-accent">▶</span>
         )}
         {isRunning && (
-          <span className="text-xs text-charcoal/30">⏸</span>
+          <span className="text-xs text-ink/30">⏸</span>
         )}
       </button>
     );
@@ -112,7 +112,7 @@ export default function Timer({
             fill="none"
             stroke="currentColor"
             strokeWidth="1.5"
-            className="text-mist"
+            className="text-edge"
           />
           <circle
             cx="32"
@@ -124,14 +124,14 @@ export default function Timer({
             strokeDasharray={`${2 * Math.PI * 28}`}
             strokeDashoffset={`${2 * Math.PI * 28 * (1 - progress)}`}
             strokeLinecap="round"
-            className="text-sage transition-all duration-1000"
+            className="text-accent transition-all duration-1000"
           />
         </svg>
-        <span className="absolute text-sm tabular-nums font-light text-charcoal/60">
+        <span className="absolute text-sm tabular-nums font-light text-ink/60">
           {isComplete ? "Reset" : formatTimer(remaining)}
         </span>
       </button>
-      <span className="text-xs text-charcoal/30">
+      <span className="text-xs text-ink/30">
         {isComplete ? "Done" : isRunning ? "Tap to pause" : "Tap to start"}
       </span>
     </div>

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -78,8 +78,8 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
         }}
         className={`cursor-pointer rounded-xl border-2 border-dashed p-12 text-center transition-all ${
           isDragging
-            ? "border-sage bg-sage/5"
-            : "border-mist hover:border-sage/50"
+            ? "border-accent bg-accent/5"
+            : "border-edge hover:border-accent/50"
         }`}
       >
         <input
@@ -90,13 +90,13 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
           className="hidden"
         />
 
-        <div className="mx-auto mb-4 h-12 w-12 rounded-full bg-mist/40 p-3">
+        <div className="mx-auto mb-4 h-12 w-12 rounded-full bg-edge/40 p-3">
           <svg
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
             strokeWidth={1.5}
-            className="h-full w-full text-charcoal/40"
+            className="h-full w-full text-ink/40"
           >
             <path
               strokeLinecap="round"
@@ -107,13 +107,13 @@ export default function UploadZone({ onFileLoaded }: UploadZoneProps) {
         </div>
 
         {fileName ? (
-          <p className="text-sm text-sage">{fileName}</p>
+          <p className="text-sm text-accent">{fileName}</p>
         ) : (
           <>
-            <p className="text-sm font-medium text-charcoal/60">
+            <p className="text-sm font-medium text-ink/60">
               Drop your Claude export here
             </p>
-            <p className="mt-1 text-xs text-charcoal/30">
+            <p className="mt-1 text-xs text-ink/30">
               JSON file from claude.ai → Settings → Export Data
             </p>
           </>

--- a/src/components/VoiceSelector.tsx
+++ b/src/components/VoiceSelector.tsx
@@ -59,7 +59,7 @@ export default function VoiceSelector({
   }, [loaded, voices.length, selectedVoiceId, onSelect]);
 
   if (!loaded) {
-    return <div className="text-xs text-charcoal/30">Loading voices...</div>;
+    return <div className="text-xs text-ink/30">Loading voices...</div>;
   }
 
   const isCustomSelected =
@@ -67,7 +67,7 @@ export default function VoiceSelector({
 
   return (
     <div className="fade-in space-y-3">
-      <label className="block text-xs font-medium text-charcoal/50">
+      <label className="block text-xs font-medium text-ink/50">
         Voice
       </label>
 
@@ -78,8 +78,8 @@ export default function VoiceSelector({
             onClick={() => onSelect(voice.id)}
             className={`rounded-full border px-3 py-1.5 text-xs transition-all ${
               selectedVoiceId === voice.id
-                ? "border-sage bg-sage/10 text-sage"
-                : "border-mist text-charcoal/40 hover:border-sage/40 hover:text-charcoal/60"
+                ? "border-accent bg-accent/10 text-accent"
+                : "border-edge text-ink/40 hover:border-accent/40 hover:text-ink/60"
             }`}
             title={voice.description}
           >
@@ -89,7 +89,7 @@ export default function VoiceSelector({
 
         {/* If no voices loaded, show a default option */}
         {voices.length === 0 && (
-          <span className="rounded-full border border-sage bg-sage/10 px-3 py-1.5 text-xs text-sage">
+          <span className="rounded-full border border-accent bg-accent/10 px-3 py-1.5 text-xs text-accent">
             Default voice
           </span>
         )}
@@ -98,8 +98,8 @@ export default function VoiceSelector({
           onClick={() => setShowCustom(!showCustom)}
           className={`rounded-full border px-3 py-1.5 text-xs transition-all ${
             isCustomSelected && customId
-              ? "border-sage bg-sage/10 text-sage"
-              : "border-mist text-charcoal/40 hover:border-sage/40 hover:text-charcoal/60"
+              ? "border-accent bg-accent/10 text-accent"
+              : "border-edge text-ink/40 hover:border-accent/40 hover:text-ink/60"
           }`}
         >
           Custom ID
@@ -113,14 +113,14 @@ export default function VoiceSelector({
             value={customId}
             onChange={(e) => setCustomId(e.target.value)}
             placeholder="ElevenLabs Voice ID"
-            className="flex-1 rounded-lg border border-mist bg-white/50 px-3 py-2 text-xs transition-colors placeholder:text-charcoal/30 focus:border-sage focus:outline-none"
+            className="flex-1 rounded-lg border border-edge bg-white/50 px-3 py-2 text-xs transition-colors placeholder:text-ink/30 focus:border-accent focus:outline-none"
           />
           <button
             onClick={() => {
               if (customId.trim()) onSelect(customId.trim());
             }}
             disabled={!customId.trim()}
-            className="rounded-lg bg-charcoal px-3 py-2 text-xs text-cream transition-all hover:bg-deep disabled:opacity-30"
+            className="rounded-lg bg-ink px-3 py-2 text-xs text-surface transition-all hover:bg-emphasis disabled:opacity-30"
           >
             Use
           </button>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,12 +1,12 @@
 @import "tailwindcss";
 
 @theme {
-  --color-cream: #F5F0EB;
-  --color-charcoal: #2C2C2C;
-  --color-sage: #8B9D83;
-  --color-clay: #C4A882;
-  --color-mist: #D4D0CB;
-  --color-deep: #1A1A1A;
+  --color-surface: #F5F0EB;
+  --color-ink: #2C2C2C;
+  --color-accent: #8B9D83;
+  --color-warm: #C4A882;
+  --color-edge: #D4D0CB;
+  --color-emphasis: #1A1A1A;
 }
 
 @layer base {
@@ -19,12 +19,12 @@
 
   /* ─── Aura Theme: override Tailwind color variables ─── */
   .theme-aura {
-    --color-cream: #F8F4FF;
-    --color-charcoal: #2D2640;
-    --color-sage: #9B8EC4;
-    --color-clay: #D4A0C0;
-    --color-mist: #E8E0F0;
-    --color-deep: #1C1528;
+    --color-surface: #F8F4FF;
+    --color-ink: #2D2640;
+    --color-accent: #9B8EC4;
+    --color-warm: #D4A0C0;
+    --color-edge: #E8E0F0;
+    --color-emphasis: #1C1528;
   }
 }
 


### PR DESCRIPTION
## Summary
- **Renamed all 6 color tokens** from appearance-based names to role-based names so they make sense across any theme, not just the default Minimalist
  - `cream` → `surface`, `charcoal` → `ink`, `sage` → `accent`, `clay` → `warm`, `mist` → `edge`, `deep` → `emphasis`
- **Updated all 12 components**, `globals.css`, and 4 documentation files (CLAUDE.md, both theme docs, theme-designer skill)
- Pure rename — 140 insertions, 140 deletions, zero logic changes

## Rename map
| Old (appearance) | New (role) | Usage |
|---|---|---|
| `cream` | `surface` | `bg-surface` |
| `charcoal` | `ink` | `text-ink`, `text-ink/50` |
| `sage` | `accent` | `bg-accent/10`, `border-accent` |
| `clay` | `warm` | `text-warm` |
| `mist` | `edge` | `border-edge`, `bg-edge` |
| `deep` | `emphasis` | `hover:bg-emphasis` |

## Test plan
- [ ] Verify Minimalist theme renders identically to before
- [ ] Verify Aura theme renders identically to before
- [ ] Toggle between themes — no flash or broken styles
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)