### PR TITLE
UI polish: landing page, voice dropdown, teleprompter

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import UploadZone from "@/components/UploadZone";
 import ProcessingView from "@/components/ProcessingView";
 import MeditationCard from "@/components/MeditationCard";
 import MeditationPlayer from "@/components/MeditationPlayer";
-import VoiceSelector from "@/components/VoiceSelector";
 import ThemeSelector from "@/components/ThemeSelector";
 import AuraBackground from "@/components/AuraBackground";
 import CosmicBackground from "@/components/CosmicBackground";
@@ -21,10 +20,10 @@ import {
   type ExtractionResult,
 } from "@/lib/generateMeditation";
 
-type Step = "keys" | "upload" | "processing" | "gallery" | "reader";
+type Step = "landing" | "keys" | "upload" | "processing" | "gallery" | "reader";
 
 export default function Home() {
-  const [step, setStep] = useState<Step>("keys");
+  const [step, setStep] = useState<Step>("landing");
   const [apiKeys, setApiKeys] = useState<ApiKeyConfig | null>(null);
   const [processing, setProcessing] = useState<ProcessingState>({
     stage: "idle",
@@ -34,7 +33,6 @@ export default function Home() {
   const [selectedMeditation, setSelectedMeditation] =
     useState<Meditation | null>(null);
   const [serverHasKeys, setServerHasKeys] = useState(false);
-  const [selectedVoiceId, setSelectedVoiceId] = useState("");
   const [hasElevenLabsKey, setHasElevenLabsKey] = useState(false);
   const [theme, setTheme] = useState<Theme>("minimalist");
   const [importDate, setImportDate] = useState<string | null>(null);
@@ -329,6 +327,68 @@ export default function Home() {
 
       {/* Steps */}
       <div className={step === "reader" ? "w-full" : "w-full max-w-md"}>
+        {step === "landing" && (
+          <div className="fade-in space-y-10 text-center">
+            <p className="text-lg font-light leading-relaxed text-ink/70">
+              Stillpoint creates 100% personalized meditations based on
+              themes from your Claude conversations.
+            </p>
+
+            <div className="space-y-6">
+              <div className="rounded-xl border border-edge bg-white/40 p-5 text-center">
+                <h3 className="mb-2 font-display text-xl font-light text-ink">Completely private</h3>
+                <p className="text-sm leading-relaxed text-ink/50">
+                  Your conversations never leave your device. Everything is
+                  parsed in your browser — no one can ever see your data.
+                  No accounts, no tracking, no servers storing anything.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-edge bg-white/40 p-5 text-center">
+                <h3 className="mb-2 font-display text-xl font-light text-ink">Deeply personal</h3>
+                <p className="text-sm leading-relaxed text-ink/50">
+                  Not generic &ldquo;calm your mind&rdquo; scripts. Meditations crafted
+                  from the emotional patterns and growth edges in your own
+                  conversations — targeting what you actually need right now.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-edge bg-white/40 p-5 text-center">
+                <h3 className="mb-2 font-display text-xl font-light text-ink">Beautiful themes</h3>
+                <p className="text-sm leading-relaxed text-ink/50">
+                  Four visual themes to match your mood — try the selector above.
+                  Run locally with Claude Code and use the Theme Designer skill
+                  to create your own.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-edge bg-white/40 p-5 text-center">
+                <h3 className="mb-2 font-display text-xl font-light text-ink">Listen or read</h3>
+                <p className="text-sm leading-relaxed text-ink/50">
+                  Generate high-quality audio with ElevenLabs voices, listen
+                  with built-in browser voices, or read at your own pace with a
+                  guided teleprompter.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-edge bg-white/40 p-5 text-center">
+                <h3 className="mb-2 font-display text-xl font-light text-ink">Your own space</h3>
+                <p className="text-sm leading-relaxed text-ink/50">
+                  Open source and free. Deploy to Vercel in minutes for a
+                  personal meditation app you can reach from any device.
+                </p>
+              </div>
+            </div>
+
+            <button
+              onClick={() => setStep(serverHasKeys ? "upload" : "keys")}
+              className="w-full rounded-lg bg-ink px-6 py-3 text-sm font-medium text-surface transition-all hover:bg-emphasis aura-btn"
+            >
+              Get Started
+            </button>
+          </div>
+        )}
+
         {step === "keys" && (
           <ApiKeySetup
             onComplete={handleKeysComplete}
@@ -355,6 +415,7 @@ export default function Home() {
                     claude.ai/settings
                   </a>
                 </li>
+                <li>Click &quot;Privacy&quot;</li>
                 <li>Click &quot;Export Data&quot;</li>
                 <li>Check your email for the download link</li>
                 <li>Download the ZIP and drop it here</li>
@@ -425,13 +486,6 @@ export default function Home() {
                 </p>
               );
             })()}
-            {hasElevenLabsKey && (
-              <VoiceSelector
-                selectedVoiceId={selectedVoiceId}
-                onSelect={setSelectedVoiceId}
-                elevenLabsKey={apiKeys?.elevenLabsKey}
-              />
-            )}
             {meditations.map((m) => (
               <MeditationCard
                 key={m.id}
@@ -459,7 +513,6 @@ export default function Home() {
         {step === "reader" && selectedMeditation && (
           <MeditationPlayer
             meditation={selectedMeditation}
-            voiceId={selectedVoiceId}
             elevenLabsKey={
               hasElevenLabsKey
                 ? apiKeys?.elevenLabsKey

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -134,8 +134,9 @@ function WebSpeechPlayer({ script }: { script: string }) {
     }
 
     function loadVoices() {
+      const allowedNames = ["Moira", "Karen", "Daniel", "Rishi", "Tessa"];
       const available = speechSynthesis.getVoices().filter(
-        (v) => v.lang.startsWith("en")
+        (v) => allowedNames.some((name) => v.name.includes(name))
       );
       setVoices(available);
     }

--- a/src/components/MeditationCard.tsx
+++ b/src/components/MeditationCard.tsx
@@ -43,12 +43,8 @@ export default function MeditationCard({
         {meditation.capacity}
       </p>
 
-      <div className="mt-4 flex items-center gap-3 text-xs text-ink/30">
-        <span>{meditation.duration} min</span>
-        <span>·</span>
-        <span className="transition-colors group-hover:text-accent">
-          Read meditation →
-        </span>
+      <div className="mt-4 text-xs text-ink/30">
+        {meditation.duration} min
       </div>
     </button>
   );

--- a/src/components/MeditationPlayer.tsx
+++ b/src/components/MeditationPlayer.tsx
@@ -2,28 +2,43 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { MEDITATION_APPROACHES, LEGACY_MEDITATION_TYPES } from "@/lib/meditationTypes";
-import type { LegacyMeditationType } from "@/lib/types";
-import BreathGuide from "@/components/BreathGuide";
-import AudioPlayer from "@/components/AudioPlayer";
-import Timer from "@/components/Timer";
+import type { LegacyMeditationType, Voice } from "@/lib/types";
 import AuraBackground from "@/components/AuraBackground";
 import CosmicBackground from "@/components/CosmicBackground";
 import SunnyBackground from "@/components/SunnyBackground";
 import { getStoredTheme, type Theme } from "@/components/ThemeSelector";
 import type { Meditation } from "@/lib/types";
 
+const ALLOWED_BROWSER_VOICES = ["Moira", "Karen", "Daniel", "Rishi", "Tessa"];
+
 interface MeditationPlayerProps {
   meditation: Meditation;
-  voiceId: string;
   elevenLabsKey?: string;
   onBack: () => void;
   onMeditationUpdate: (updated: Meditation) => void;
 }
 
-/** Split script into segments for display and highlighting */
-function parseScript(script: string): ScriptSegment[] {
+// ── Sentence-based script parsing for teleprompter ──
+
+interface SentenceSegment {
+  type: "sentence";
+  text: string;
+  wordCount: number;
+  sentenceIndex: number;
+}
+
+interface MarkerSegment {
+  type: "pause" | "breathe" | "bell";
+  text: string;
+  seconds?: number;
+}
+
+type TeleprompterSegment = SentenceSegment | MarkerSegment;
+
+function parseSentences(script: string): TeleprompterSegment[] {
   const parts = script.split(/(\[(?:pause \d+s|breathe|bell)\])/g);
-  const segments: ScriptSegment[] = [];
+  const segments: TeleprompterSegment[] = [];
+  let sentenceIndex = 0;
 
   for (const part of parts) {
     if (!part.trim()) continue;
@@ -35,14 +50,17 @@ function parseScript(script: string): ScriptSegment[] {
     } else if (part === "[bell]") {
       segments.push({ type: "bell", text: part });
     } else {
-      // Split text into words for highlighting
-      const words = part.split(/(\s+)/);
-      for (const word of words) {
-        if (word.trim()) {
-          segments.push({ type: "word", text: word });
-        } else if (word) {
-          segments.push({ type: "space", text: word });
-        }
+      // Split into sentences on . ! ? followed by space or end of string
+      const sentences = part.split(/(?<=[.!?])\s+/).filter((s) => s.trim());
+      for (const sentence of sentences) {
+        const wordCount = sentence.trim().split(/\s+/).length;
+        segments.push({
+          type: "sentence",
+          text: sentence.trim(),
+          wordCount,
+          sentenceIndex,
+        });
+        sentenceIndex++;
       }
     }
   }
@@ -50,13 +68,24 @@ function parseScript(script: string): ScriptSegment[] {
   return segments;
 }
 
-interface ScriptSegment {
-  type: "word" | "space" | "pause" | "breathe" | "bell";
-  text: string;
-  seconds?: number;
+/** Strip meditation markers from script for speech synthesis */
+function cleanScriptForSpeech(script: string): string {
+  return script
+    .replace(/\[pause (\d+)s\]/g, (_m, s) => ", " + ".".repeat(Number(s)) + " ")
+    .replace(/\[breathe\]/g, ", ... breathe ... ")
+    .replace(/\[bell\]/g, "")
+    .trim();
+}
+
+interface UnifiedVoice {
+  id: string;
+  name: string;
+  type: "elevenlabs" | "webspeech";
+  nativeVoice?: SpeechSynthesisVoice;
 }
 
 const SPEEDS = [0.75, 1, 1.25] as const;
+const WORDS_PER_SECOND = 3.0; // ~180 wpm — comfortable reading pace
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -66,7 +95,6 @@ function formatTime(seconds: number): string {
 
 export default function MeditationPlayer({
   meditation,
-  voiceId,
   elevenLabsKey,
   onBack,
   onMeditationUpdate,
@@ -86,24 +114,41 @@ export default function MeditationPlayer({
   const [speedIndex, setSpeedIndex] = useState(1);
   const [isAudioLoaded, setIsAudioLoaded] = useState(false);
 
+  // Voice state
+  const [voices, setVoices] = useState<UnifiedVoice[]>([]);
+  const [selectedVoiceId, setSelectedVoiceId] = useState("");
+  const [voicesLoaded, setVoicesLoaded] = useState(false);
+
   // Generation state
   const [isGeneratingAudio, setIsGeneratingAudio] = useState(false);
   const [audioError, setAudioError] = useState<string | null>(null);
 
+  // Web Speech state
+  const [isWebSpeechPlaying, setIsWebSpeechPlaying] = useState(false);
+
+  // Teleprompter state
+  const [activeSentenceIndex, setActiveSentenceIndex] = useState(-1);
+  const [isReading, setIsReading] = useState(false);
+  const readingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // UI state
-  const [showBreathGuide, setShowBreathGuide] = useState(false);
-  const [breathActive, setBreathActive] = useState(false);
-  const [showTimer, setShowTimer] = useState(false);
-  const [timerRunning, setTimerRunning] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [theme, setTheme] = useState<Theme>("minimalist");
 
-  // Script
-  const segments = useRef(parseScript(meditation.script)).current;
+  // Script — sentence-based for teleprompter
+  const teleprompterSegments = useRef(parseSentences(meditation.script)).current;
   const scriptContainerRef = useRef<HTMLDivElement>(null);
 
+  // Derived: only sentence segments (for timing calculations)
+  const sentences = teleprompterSegments.filter(
+    (s): s is SentenceSegment => s.type === "sentence"
+  );
+  const totalSentences = sentences.length;
+
+  const selectedVoice = voices.find((v) => v.id === selectedVoiceId);
+  const isElevenLabs = selectedVoice?.type === "elevenlabs";
   const hasAudio = !!meditation.audioBase64;
-  const canGenerateAudio = !!elevenLabsKey;
+  const audioMatchesVoice = hasAudio && meditation.voiceId === selectedVoiceId;
 
   // Track theme
   useEffect(() => {
@@ -121,7 +166,71 @@ export default function MeditationPlayer({
     bellRef.current.volume = 0.5;
   }, []);
 
-  // Load audio when available
+  // Fetch voices — ElevenLabs if key provided, otherwise Web Speech
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadVoices() {
+      if (elevenLabsKey) {
+        try {
+          const res = await fetch("/api/voices", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ apiKey: elevenLabsKey }),
+          });
+          if (res.ok && !cancelled) {
+            const data = await res.json();
+            if (data.voices?.length > 0) {
+              const mapped: UnifiedVoice[] = data.voices.map((v: Voice) => ({
+                id: v.id,
+                name: v.name,
+                type: "elevenlabs" as const,
+              }));
+              setVoices(mapped);
+              setSelectedVoiceId(mapped[0].id);
+              setVoicesLoaded(true);
+              return;
+            }
+          }
+        } catch {
+          // Fall through to web speech
+        }
+      }
+
+      // Web Speech fallback
+      if (typeof window === "undefined" || !window.speechSynthesis) {
+        if (!cancelled) setVoicesLoaded(true);
+        return;
+      }
+
+      function loadBrowserVoices() {
+        if (cancelled) return;
+        const available = speechSynthesis.getVoices().filter((v) =>
+          ALLOWED_BROWSER_VOICES.some((name) => v.name.includes(name))
+        );
+        const mapped: UnifiedVoice[] = available.map((v) => ({
+          id: `webspeech:${v.name}`,
+          name: v.name.replace(/\(.*\)/, "").trim(),
+          type: "webspeech" as const,
+          nativeVoice: v,
+        }));
+        if (mapped.length > 0) {
+          setVoices(mapped);
+          setSelectedVoiceId(mapped[0].id);
+        }
+        setVoicesLoaded(true);
+      }
+
+      loadBrowserVoices();
+      speechSynthesis.addEventListener("voiceschanged", loadBrowserVoices);
+      return () => speechSynthesis.removeEventListener("voiceschanged", loadBrowserVoices);
+    }
+
+    loadVoices();
+    return () => { cancelled = true; };
+  }, [elevenLabsKey]);
+
+  // Load ElevenLabs audio when available
   useEffect(() => {
     if (!meditation.audioBase64) {
       setIsAudioLoaded(false);
@@ -138,6 +247,7 @@ export default function MeditationPlayer({
     audio.addEventListener("ended", () => {
       setIsPlaying(false);
       setCurrentTime(0);
+      setActiveSentenceIndex(-1);
       bellRef.current?.play().catch(() => {});
     });
 
@@ -148,35 +258,85 @@ export default function MeditationPlayer({
     };
   }, [meditation.audioBase64]);
 
-  const togglePlay = useCallback(() => {
-    const audio = audioRef.current;
-    if (!audio || !isAudioLoaded) return;
-    if (isPlaying) {
-      audio.pause();
-    } else {
-      audio.play();
-      setTimerRunning(true);
+  // ── Teleprompter: ElevenLabs audio time-based sentence sync ──
+  useEffect(() => {
+    if (!isPlaying || !isElevenLabs || !audioMatchesVoice || duration === 0) return;
+
+    // Estimate sentence timings proportionally by word count
+    const totalWords = sentences.reduce((sum, s) => sum + s.wordCount, 0);
+    let cumWords = 0;
+    const timings = sentences.map((s) => {
+      const start = (cumWords / totalWords) * duration;
+      cumWords += s.wordCount;
+      const end = (cumWords / totalWords) * duration;
+      return { start, end, index: s.sentenceIndex };
+    });
+
+    const interval = setInterval(() => {
+      const t = audioRef.current?.currentTime ?? 0;
+      const active = timings.find((tm) => t >= tm.start && t < tm.end);
+      if (active) {
+        setActiveSentenceIndex(active.index);
+      }
+    }, 200);
+
+    return () => clearInterval(interval);
+  }, [isPlaying, isElevenLabs, audioMatchesVoice, duration, sentences]);
+
+  // ── Teleprompter: reading mode auto-advance ──
+  useEffect(() => {
+    if (!isReading) return;
+
+    function advanceSentence(idx: number) {
+      if (idx >= totalSentences) {
+        // Done reading
+        setIsReading(false);
+        setIsPlaying(false);
+        setActiveSentenceIndex(-1);
+        bellRef.current?.play().catch(() => {});
+        return;
+      }
+
+      setActiveSentenceIndex(sentences[idx].sentenceIndex);
+
+      // Check if next teleprompter segment after this sentence is a marker
+      const teleIdx = teleprompterSegments.findIndex(
+        (s) => s.type === "sentence" && (s as SentenceSegment).sentenceIndex === sentences[idx].sentenceIndex
+      );
+      let extraDelay = 0;
+      // Look ahead for pause/breathe markers before the next sentence
+      for (let i = teleIdx + 1; i < teleprompterSegments.length; i++) {
+        const seg = teleprompterSegments[i];
+        if (seg.type === "sentence") break;
+        if (seg.type === "pause" && seg.seconds) extraDelay += seg.seconds * 1000;
+        if (seg.type === "breathe") extraDelay += 4000;
+      }
+
+      const readTime = (sentences[idx].wordCount / WORDS_PER_SECOND) * 1000;
+      readingTimerRef.current = setTimeout(
+        () => advanceSentence(idx + 1),
+        readTime + extraDelay
+      );
     }
-    setIsPlaying(!isPlaying);
-  }, [isPlaying, isAudioLoaded]);
 
-  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    const time = parseFloat(e.target.value);
-    audio.currentTime = time;
-    setCurrentTime(time);
-  }, []);
+    advanceSentence(0);
 
-  const cycleSpeed = useCallback(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    const next = (speedIndex + 1) % SPEEDS.length;
-    setSpeedIndex(next);
-    audio.playbackRate = SPEEDS[next];
-  }, [speedIndex]);
+    return () => {
+      if (readingTimerRef.current) clearTimeout(readingTimerRef.current);
+    };
+  }, [isReading, totalSentences, sentences, teleprompterSegments]);
 
-  const generateAudio = useCallback(async () => {
+  // ── Teleprompter: auto-scroll active sentence into view ──
+  useEffect(() => {
+    if (activeSentenceIndex < 0) return;
+    const el = scriptContainerRef.current?.querySelector(
+      `[data-sentence="${activeSentenceIndex}"]`
+    );
+    el?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [activeSentenceIndex]);
+
+  // Generate ElevenLabs audio
+  const generateAudio = useCallback(async (voiceId: string) => {
     setIsGeneratingAudio(true);
     setAudioError(null);
 
@@ -208,7 +368,132 @@ export default function MeditationPlayer({
     } finally {
       setIsGeneratingAudio(false);
     }
-  }, [meditation, voiceId, elevenLabsKey, onMeditationUpdate]);
+  }, [meditation, elevenLabsKey, onMeditationUpdate]);
+
+  // Unified play/pause
+  const togglePlay = useCallback(() => {
+    // If reading mode is active, stop it
+    if (isReading) {
+      setIsReading(false);
+      setIsPlaying(false);
+      setActiveSentenceIndex(-1);
+      if (readingTimerRef.current) clearTimeout(readingTimerRef.current);
+      return;
+    }
+
+    if (!selectedVoice) {
+      // No voice available — start reading mode
+      setIsReading(true);
+      setIsPlaying(true);
+      return;
+    }
+
+    if (selectedVoice.type === "elevenlabs") {
+      if (isPlaying) {
+        audioRef.current?.pause();
+        setIsPlaying(false);
+        return;
+      }
+
+      if (audioMatchesVoice && isAudioLoaded) {
+        audioRef.current?.play();
+        setIsPlaying(true);
+      } else if (!isGeneratingAudio) {
+        generateAudio(selectedVoice.id);
+      }
+    } else {
+      // Web Speech mode
+      if (isWebSpeechPlaying) {
+        speechSynthesis.cancel();
+        setIsWebSpeechPlaying(false);
+        setIsPlaying(false);
+        setActiveSentenceIndex(-1);
+        return;
+      }
+
+      const cleaned = cleanScriptForSpeech(meditation.script);
+      const utterance = new SpeechSynthesisUtterance(cleaned);
+      utterance.rate = 0.85;
+      utterance.pitch = 0.95;
+      utterance.volume = 1;
+
+      if (selectedVoice.nativeVoice) {
+        utterance.voice = selectedVoice.nativeVoice;
+      }
+
+      // Web Speech boundary events for teleprompter
+      // Build a mapping from character offset to sentence index
+      const charToSentence: Array<{ charStart: number; charEnd: number; sentenceIndex: number }> = [];
+      let charOffset = 0;
+      const cleanedSentences = cleaned.split(/(?<=[.!?])\s+/).filter((s) => s.trim());
+      for (let i = 0; i < cleanedSentences.length && i < totalSentences; i++) {
+        const start = charOffset;
+        charOffset += cleanedSentences[i].length + 1; // +1 for space
+        charToSentence.push({ charStart: start, charEnd: charOffset, sentenceIndex: i });
+      }
+
+      utterance.onboundary = (event) => {
+        const ci = event.charIndex;
+        const match = charToSentence.find((m) => ci >= m.charStart && ci < m.charEnd);
+        if (match) {
+          setActiveSentenceIndex(match.sentenceIndex);
+        }
+      };
+
+      utterance.onend = () => {
+        setIsWebSpeechPlaying(false);
+        setIsPlaying(false);
+        setActiveSentenceIndex(-1);
+        bellRef.current?.play().catch(() => {});
+      };
+
+      speechSynthesis.speak(utterance);
+      setIsWebSpeechPlaying(true);
+      setIsPlaying(true);
+      setActiveSentenceIndex(0);
+    }
+  }, [selectedVoice, isPlaying, isReading, isWebSpeechPlaying, audioMatchesVoice, isAudioLoaded, isGeneratingAudio, generateAudio, meditation.script, totalSentences]);
+
+  // Auto-play after ElevenLabs audio generation completes
+  useEffect(() => {
+    if (isAudioLoaded && isGeneratingAudio === false && audioMatchesVoice && !isPlaying) {
+      audioRef.current?.play();
+      setIsPlaying(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAudioLoaded]);
+
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const time = parseFloat(e.target.value);
+    audio.currentTime = time;
+    setCurrentTime(time);
+  }, []);
+
+  const cycleSpeed = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const next = (speedIndex + 1) % SPEEDS.length;
+    setSpeedIndex(next);
+    audio.playbackRate = SPEEDS[next];
+  }, [speedIndex]);
+
+  // Stop web speech / reading when voice changes
+  const handleVoiceChange = useCallback((newVoiceId: string) => {
+    if (isWebSpeechPlaying) {
+      speechSynthesis.cancel();
+      setIsWebSpeechPlaying(false);
+      setIsPlaying(false);
+    }
+    if (isReading) {
+      setIsReading(false);
+      setIsPlaying(false);
+      if (readingTimerRef.current) clearTimeout(readingTimerRef.current);
+    }
+    setActiveSentenceIndex(-1);
+    setSelectedVoiceId(newVoiceId);
+  }, [isWebSpeechPlaying, isReading]);
 
   // Auto-hide controls after inactivity
   useEffect(() => {
@@ -227,6 +512,7 @@ export default function MeditationPlayer({
   }, []);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+  const showSeekbar = isElevenLabs && audioMatchesVoice;
 
   return (
     <div
@@ -254,37 +540,20 @@ export default function MeditationPlayer({
           Back
         </button>
 
-        <div className="flex items-center gap-3">
-          {/* Breath guide toggle */}
-          <button
-            onClick={() => {
-              setShowBreathGuide(!showBreathGuide);
-              if (showBreathGuide) setBreathActive(false);
-            }}
-            className={`rounded-full px-3 py-1.5 text-xs transition-all ${
-              showBreathGuide
-                ? "bg-accent/20 text-accent"
-                : "text-ink/30 hover:text-ink/50"
-            }`}
+        {/* Voice dropdown */}
+        {voicesLoaded && voices.length > 0 && (
+          <select
+            value={selectedVoiceId}
+            onChange={(e) => handleVoiceChange(e.target.value)}
+            className="rounded-lg border border-edge bg-white/40 px-3 py-1.5 text-xs text-ink/60 backdrop-blur-sm transition-colors focus:border-accent focus:outline-none"
           >
-            Breathe
-          </button>
-
-          {/* Timer toggle */}
-          <button
-            onClick={() => {
-              setShowTimer(!showTimer);
-              if (showTimer) setTimerRunning(false);
-            }}
-            className={`rounded-full px-3 py-1.5 text-xs transition-all ${
-              showTimer
-                ? "bg-accent/20 text-accent"
-                : "text-ink/30 hover:text-ink/50"
-            }`}
-          >
-            Timer
-          </button>
-        </div>
+            {voices.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {/* Main content area */}
@@ -302,41 +571,14 @@ export default function MeditationPlayer({
           </p>
         </div>
 
-        {/* Breath guide overlay */}
-        {showBreathGuide && (
-          <div className="mb-6 fade-in">
-            <BreathGuide
-              active={breathActive}
-              compact
-              onToggle={setBreathActive}
-            />
-          </div>
-        )}
-
-        {/* Timer overlay */}
-        {showTimer && (
-          <div className="mb-6 fade-in">
-            <Timer
-              duration={meditation.duration}
-              isRunning={timerRunning}
-              compact
-              onToggle={setTimerRunning}
-              onComplete={() => {
-                bellRef.current?.play().catch(() => {});
-                setTimerRunning(false);
-              }}
-            />
-          </div>
-        )}
-
-        {/* Script text */}
+        {/* Script text — teleprompter with sentence highlighting */}
         <div
           ref={scriptContainerRef}
           className="flex-1 overflow-y-auto pb-32 scrollbar-hide"
           style={{ maxWidth: "36rem" }}
         >
-          <div className="font-display text-lg font-light leading-[2] text-ink/80 sm:text-xl sm:leading-[2.1]">
-            {segments.map((seg, i) => {
+          <div className="font-display text-lg font-light leading-[2] sm:text-xl sm:leading-[2.1]">
+            {teleprompterSegments.map((seg, i) => {
               if (seg.type === "pause") {
                 return (
                   <span
@@ -367,13 +609,28 @@ export default function MeditationPlayer({
                   </span>
                 );
               }
-              if (seg.type === "space") {
-                return <span key={i}>{seg.text}</span>;
+              // Sentence
+              if (seg.type !== "sentence") return null;
+              const si = seg.sentenceIndex;
+              const isActive = activeSentenceIndex >= 0;
+              let colorClass = "text-ink/80"; // default: no teleprompter active
+              if (isActive) {
+                if (si === activeSentenceIndex) {
+                  colorClass = "text-ink";
+                } else if (si < activeSentenceIndex) {
+                  colorClass = "text-ink/30";
+                } else {
+                  colorClass = "text-ink/50";
+                }
               }
-              // word
+
               return (
-                <span key={i} className="transition-colors duration-200">
-                  {seg.text}
+                <span
+                  key={i}
+                  data-sentence={si}
+                  className={`transition-colors duration-500 ${colorClass}`}
+                >
+                  {seg.text}{" "}
                 </span>
               );
             })}
@@ -387,77 +644,78 @@ export default function MeditationPlayer({
           showControls || !isPlaying ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
         }`}
       >
-        {hasAudio ? (
-          <div className="mx-auto flex max-w-lg items-center gap-4">
-            {/* Play/Pause */}
-            <button
-              onClick={togglePlay}
-              disabled={!isAudioLoaded}
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-all hover:bg-emphasis disabled:opacity-30"
-            >
-              {isPlaying ? (
-                <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
-                  <rect x="6" y="4" width="4" height="16" rx="1" />
-                  <rect x="14" y="4" width="4" height="16" rx="1" />
-                </svg>
-              ) : (
-                <svg viewBox="0 0 24 24" fill="currentColor" className="ml-0.5 h-5 w-5">
-                  <path d="M8 5v14l11-7z" />
-                </svg>
-              )}
-            </button>
-
-            {/* Seekbar */}
-            <div className="flex flex-1 flex-col gap-1">
-              <input
-                type="range"
-                min={0}
-                max={duration || 0}
-                step={0.1}
-                value={currentTime}
-                onChange={handleSeek}
-                className="h-1 w-full cursor-pointer appearance-none rounded-full bg-edge accent-accent"
-                style={{
-                  background: `linear-gradient(to right, var(--accent) ${progress}%, ${
-                    "var(--edge)"
-                  } ${progress}%)`,
-                }}
-              />
-              <div className="flex justify-between text-xs tabular-nums text-ink/30">
-                <span>{formatTime(currentTime)}</span>
-                <span>{formatTime(duration)}</span>
-              </div>
-            </div>
-
-            {/* Speed */}
-            <button
-              onClick={cycleSpeed}
-              className="shrink-0 rounded-full border border-edge px-2.5 py-1 text-xs text-ink/40 transition-colors hover:border-accent hover:text-ink/60"
-            >
-              {SPEEDS[speedIndex]}x
-            </button>
-          </div>
-        ) : (
-          <div className="mx-auto max-w-lg space-y-3">
-            {canGenerateAudio && (
-              <div className="space-y-2">
-                <button
-                  onClick={generateAudio}
-                  disabled={isGeneratingAudio}
-                  className="w-full rounded-xl border border-edge bg-white/40 px-4 py-3 text-sm text-ink/60 transition-all hover:border-accent hover:text-ink disabled:opacity-50"
-                >
-                  {isGeneratingAudio
-                    ? "Generating audio..."
-                    : "Generate with ElevenLabs voice"}
-                </button>
-                {audioError && (
-                  <p className="text-center text-xs text-red-500/70">{audioError}</p>
-                )}
-              </div>
+        <div className="mx-auto flex max-w-lg items-center gap-4">
+          {/* Play/Pause */}
+          <button
+            onClick={togglePlay}
+            disabled={isGeneratingAudio}
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-all hover:bg-emphasis disabled:opacity-30"
+          >
+            {isGeneratingAudio ? (
+              <svg viewBox="0 0 24 24" fill="none" className="h-5 w-5 animate-spin">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="31.4" strokeDashoffset="10" strokeLinecap="round" />
+              </svg>
+            ) : isPlaying ? (
+              <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <rect x="6" y="4" width="4" height="16" rx="1" />
+                <rect x="14" y="4" width="4" height="16" rx="1" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" fill="currentColor" className="ml-0.5 h-5 w-5">
+                <path d="M8 5v14l11-7z" />
+              </svg>
             )}
-            <AudioPlayer script={meditation.script} />
-          </div>
-        )}
+          </button>
+
+          {showSeekbar ? (
+            <>
+              {/* Seekbar — only for ElevenLabs audio */}
+              <div className="flex flex-1 flex-col gap-1">
+                <input
+                  type="range"
+                  min={0}
+                  max={duration || 0}
+                  step={0.1}
+                  value={currentTime}
+                  onChange={handleSeek}
+                  className="h-1 w-full cursor-pointer appearance-none rounded-full bg-edge accent-accent"
+                  style={{
+                    background: `linear-gradient(to right, var(--accent) ${progress}%, var(--edge) ${progress}%)`,
+                  }}
+                />
+                <div className="flex justify-between text-xs tabular-nums text-ink/30">
+                  <span>{formatTime(currentTime)}</span>
+                  <span>{formatTime(duration)}</span>
+                </div>
+              </div>
+
+              {/* Speed */}
+              <button
+                onClick={cycleSpeed}
+                className="shrink-0 rounded-full border border-edge px-2.5 py-1 text-xs text-ink/40 transition-colors hover:border-accent hover:text-ink/60"
+              >
+                {SPEEDS[speedIndex]}x
+              </button>
+            </>
+          ) : (
+            <div className="flex-1">
+              <p className="text-xs text-ink/40">
+                {isGeneratingAudio
+                  ? "Generating audio..."
+                  : isReading
+                    ? "Reading..."
+                    : isPlaying
+                      ? `Playing with ${selectedVoice?.name ?? "browser voice"}...`
+                      : voices.length > 0
+                        ? "Press play to listen"
+                        : "Press play to read"}
+              </p>
+              {audioError && (
+                <p className="mt-1 text-xs text-red-500/70">{audioError}</p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Landing page** with value props for first-time visitors (privacy, personalization, themes, audio, deploy-to-Vercel)
- **Unified voice dropdown** in MeditationPlayer — ElevenLabs voices if key provided, otherwise browser voices (Moira, Karen, Daniel, Rishi, Tessa). Auto-generates audio on play.
- **Teleprompter** auto-scrolls and highlights the active sentence, synced to ElevenLabs audio timing, Web Speech boundary events, or a reading-speed auto-advance for text-only mode
- Removed BreathGuide and Timer from player
- Removed "Read meditation →" text from cards
- Added "Click Privacy" step to export instructions

## Test plan
- [ ] First visit (no localStorage): landing page renders with value props and theme toggle
- [ ] "Get Started" → keys → upload flow works
- [ ] Player: voice dropdown shows ElevenLabs voices (with key) or browser voices (without)
- [ ] Player: pressing play auto-generates ElevenLabs audio then plays
- [ ] Player: Web Speech plays with selected browser voice
- [ ] Player: teleprompter highlights and scrolls during all playback modes
- [ ] Player: pressing play with no voices starts reading-mode teleprompter
- [ ] Cards show duration only, no "Read meditation" text
- [ ] Export instructions include "Click Privacy" step
- [ ] All 4 themes work on landing page and player
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)